### PR TITLE
feat(otel-hook): autoload registration of otel hook

### DIFF
--- a/hooks/OpenTelemetry/README.md
+++ b/hooks/OpenTelemetry/README.md
@@ -12,6 +12,10 @@ OpenTelemetry is an open specification for distributed tracing, metrics, and log
 
 This package also builds on various PSRs (PHP Standards Recommendations) such as the Logger interfaces (PSR-3) and the Basic and Extended Coding Standards (PSR-1 and PSR-12).
 
+### Autoloading
+
+For version of PHP 8 and higher, this package supports Composer autoloading. Thus, simply installing the package is all you need in order to immediately get started with OpenTracing for OpenFeature!
+
 ### OpenTelemetry Package Status
 
 The OpenTelemetry package for PHP is still in beta, so there could be changes required. However, it exposes global primitives for span retrieval that should not require any configuration upfront for the provider to just work.

--- a/hooks/OpenTelemetry/README.md
+++ b/hooks/OpenTelemetry/README.md
@@ -14,7 +14,7 @@ This package also builds on various PSRs (PHP Standards Recommendations) such as
 
 ### Autoloading
 
-For version of PHP 8 and higher, this package supports Composer autoloading. Thus, simply installing the package is all you need in order to immediately get started with OpenTracing for OpenFeature!
+This package supports Composer autoloading. Thus, simply installing the package is all you need in order to immediately get started with OpenTracing for OpenFeature! Examples are provided that showcase the simple setup as well. Check out the Usage section for more info.
 
 ### OpenTelemetry Package Status
 
@@ -40,6 +40,8 @@ OpenTelemetryHook::register();
 ```
 
 For more information on OpenTelemetry, check out [their documentation](https://opentelemetry.io/docs/instrumentation/php/).
+
+For more examples, see the [examples](./examples/).
 
 ## Development
 

--- a/hooks/OpenTelemetry/composer.json
+++ b/hooks/OpenTelemetry/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": "^7.4 || ^8",
-    "open-feature/sdk": "^1.1.0",
+    "open-feature/sdk": "^1.2.0",
     "open-telemetry/api": "^0.0.17"
   },
   "require-dev": {

--- a/hooks/OpenTelemetry/composer.json
+++ b/hooks/OpenTelemetry/composer.json
@@ -54,7 +54,10 @@
   "autoload": {
     "psr-4": {
       "OpenFeature\\Hooks\\OpenTelemetry\\": "src"
-    }
+    },
+    "files": [
+      "src/_autoload.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {

--- a/hooks/OpenTelemetry/composer.json
+++ b/hooks/OpenTelemetry/composer.json
@@ -112,7 +112,7 @@
     "dev:test:unit:teardown": "echo 'Tore down for unit tests...'",
     "dev:test:integration": [
       "@dev:test:integration:setup",
-      "echo 'No integration tests to run'",
+      "phpunit --colors=always --testdox --testsuite=integration",
       "@dev:test:integration:teardown"
     ],
     "dev:test:integration:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",

--- a/hooks/OpenTelemetry/examples/AutoloadOTelSDK/README.md
+++ b/hooks/OpenTelemetry/examples/AutoloadOTelSDK/README.md
@@ -1,0 +1,5 @@
+# OpenFeature OpenTelemetry Hook example
+
+This example provides an example of bootstrapping and using the OpenTelemetry hook for OpenFeature.
+
+It showcases the auto-instrumentation functionality of OpenFeature and OpenTelemetry, neither of which requiring imperative interactions with OTel to bootstrap, configure, and utilize it.

--- a/hooks/OpenTelemetry/examples/AutoloadOTelSDK/composer.json
+++ b/hooks/OpenTelemetry/examples/AutoloadOTelSDK/composer.json
@@ -10,13 +10,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "*",
-        "php-http/guzzle7-adapter": "*",
-        "slim/slim": "~4",
-        "php-di/php-di": "^6.3",
-        "php-di/slim-bridge": "^3.2",
         "open-telemetry/api": "0.0.17",
-        "open-telemetry/sdk": "0.0.17",
         "open-feature/sdk": "^1.1"
     }
 }

--- a/hooks/OpenTelemetry/examples/AutoloadOTelSDK/composer.json
+++ b/hooks/OpenTelemetry/examples/AutoloadOTelSDK/composer.json
@@ -11,6 +11,6 @@
     ],
     "require": {
         "open-telemetry/api": "0.0.17",
-        "open-feature/sdk": "^1.1"
+        "open-feature/sdk": "^1.2.0"
     }
 }

--- a/hooks/OpenTelemetry/examples/AutoloadOTelSDK/src/main.php
+++ b/hooks/OpenTelemetry/examples/AutoloadOTelSDK/src/main.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenFeature\OpenFeatureAPI;
+
+putenv('OTEL_PHP_AUTOLOAD_ENABLED=true');
+putenv('OTEL_TRACES_EXPORTER=otlp');
+putenv('OTEL_EXPORTER_OTLP_PROTOCOL=grpc');
+putenv('OTEL_METRICS_EXPORTER=otlp');
+putenv('OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc');
+putenv('OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317');
+putenv('OTEL_PHP_TRACES_PROCESSOR=batch');
+putenv('OTEL_PROPAGATORS=b3,baggage,tracecontext');
+
+echo 'autoloading SDK example starting...' . PHP_EOL;
+
+// Composer autoloader will execute SDK/_autoload.php which will register global instrumentation from environment configuration
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$client = OpenFeatureAPI::getInstance()->getClient('dev.openfeature.contrib.php.demo', '1.0.0');
+
+$version = $client->getStringValue('dev.openfeature.contrib.php.version-value', 'unknown');
+
+echo 'Version is ' . $version;

--- a/hooks/OpenTelemetry/examples/OTelManualInstrumentation/README.md
+++ b/hooks/OpenTelemetry/examples/OTelManualInstrumentation/README.md
@@ -1,3 +1,5 @@
 # OpenFeature OpenTelemetry Hook example
 
 This example provides an example of bootstrapping and using the OpenTelemetry hook for OpenFeature.
+
+It showcases how you can manually configure the OTel SDK for metrics, tracing, and more. This is then utilized under the hood by OpenFeature within its hook lifecycles to report the feature flag semantic events via the tracer. 

--- a/hooks/OpenTelemetry/examples/OTelManualInstrumentation/composer.json
+++ b/hooks/OpenTelemetry/examples/OTelManualInstrumentation/composer.json
@@ -17,6 +17,6 @@
         "php-di/slim-bridge": "^3.2",
         "open-telemetry/api": "0.0.17",
         "open-telemetry/sdk": "0.0.17",
-        "open-feature/sdk": "^1.1"
+        "open-feature/sdk": "^1.2.0"
     }
 }

--- a/hooks/OpenTelemetry/examples/OTelManualInstrumentation/src/main.php
+++ b/hooks/OpenTelemetry/examples/OTelManualInstrumentation/src/main.php
@@ -32,7 +32,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Routing\RouteContext;
 
-// Registering the OTel hook requires only the following!
+// Manually registering the OTel hook requires only the following!
 // The rest of the work is simply using OpenFeature as you normally would
 // The current context span will be used to emit trace events.
 OpenTelemetryHook::register();

--- a/hooks/OpenTelemetry/src/OpenTelemetryHook.php
+++ b/hooks/OpenTelemetry/src/OpenTelemetryHook.php
@@ -42,7 +42,7 @@ class OpenTelemetryHook implements Hook
             self::$instance = new OpenTelemetryHook();
         }
 
-        if (self::$registeredHook) {
+        if (self::$registeredHook && self::isRegisteredInHooks()) {
             return;
         }
 
@@ -87,5 +87,22 @@ class OpenTelemetryHook implements Hook
     public function supportsFlagValueType(string $flagValueType): bool
     {
         return true;
+    }
+
+    /**
+     * Hooks can be cleared by other means so we can't simply memoize whether a registration has occurred
+     *
+     * However if no registration has yet happened then we can absolutely determine that the hook will
+     * not be registered yet.
+     */
+    private static function isRegisteredInHooks(): bool
+    {
+        foreach (OpenFeatureAPI::getInstance()->getHooks() as $hook) {
+            if ($hook instanceof OpenTelemetryHook) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/hooks/OpenTelemetry/src/_autoload.php
+++ b/hooks/OpenTelemetry/src/_autoload.php
@@ -1,0 +1,4 @@
+<?php
+
+// automatically registers the OTel hook for OpenFeature
+OpenFeature\Hooks\OpenTelemetry\OpenTelemetryHook::register();

--- a/hooks/OpenTelemetry/src/_autoload.php
+++ b/hooks/OpenTelemetry/src/_autoload.php
@@ -1,4 +1,6 @@
 <?php
 
+declare(strict_types=1);
+
 // automatically registers the OTel hook for OpenFeature
 OpenFeature\Hooks\OpenTelemetry\OpenTelemetryHook::register();

--- a/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
+++ b/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
@@ -11,10 +11,26 @@ use OpenFeature\interfaces\hooks\Hook;
 
 class OpenTelemetryHookTest extends TestCase
 {
+    public function testIsRegisteredAutomatically(): void
+    {
+        // Given
+        $api = OpenFeatureAPI::getInstance();
+        $api->clearHooks();
+
+        // When
+        // simulates the composer autoload
+        require_once __DIR__ . '/../../src/_autoload.php';
+
+        // Then
+        $this->assertNotEmpty($api->getHooks());
+        $this->assertInstanceOf(Hook::class, $api->getHooks()[0]);
+    }
+
     public function testCanBeRegistered(): void
     {
         // Given
         $api = OpenFeatureAPI::getInstance();
+        $api->clearHooks();
 
         // When
         OpenTelemetryHook::register();

--- a/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
+++ b/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
@@ -45,7 +45,7 @@ class OpenTelemetryHookTest extends TestCase
 
     private function simulateAutoload(): void
     {
-        require_once __DIR__ . '/../../src/_autoload.php';
+        require __DIR__ . '/../../src/_autoload.php';
     }
 
     private function isAutoloadSupported(): bool

--- a/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
+++ b/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
@@ -9,6 +9,9 @@ use OpenFeature\Hooks\OpenTelemetry\Test\TestCase;
 use OpenFeature\OpenFeatureAPI;
 use OpenFeature\interfaces\hooks\Hook;
 
+use function phpversion;
+use function preg_match;
+
 class OpenTelemetryHookTest extends TestCase
 {
     public function testIsRegisteredAutomatically(): void
@@ -21,7 +24,8 @@ class OpenTelemetryHookTest extends TestCase
         $this->simulateAutoload();
 
         // Then
-        $this->assertNotEmpty($api->getHooks());
+
+        $this->assertCount($this->isAutoloadSupported() ? 1 : 0, $api->getHooks());
         $this->assertInstanceOf(Hook::class, $api->getHooks()[0]);
     }
 
@@ -42,5 +46,16 @@ class OpenTelemetryHookTest extends TestCase
     private function simulateAutoload(): void
     {
         require_once __DIR__ . '/../../src/_autoload.php';
+    }
+
+    private function isAutoloadSupported(): bool
+    {
+        $version = phpversion();
+
+        if (!$version) {
+            return false;
+        }
+
+        return preg_match('/8\..+/', $version) === 1;
     }
 }

--- a/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
+++ b/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
@@ -11,7 +11,7 @@ use OpenFeature\interfaces\hooks\Hook;
 
 class OpenTelemetryHookTest extends TestCase
 {
-    public function testIsRegisteredAutomatically(): void
+    public function testAutoload(): void
     {
         // Given
         $api = OpenFeatureAPI::getInstance();

--- a/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
+++ b/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
@@ -18,8 +18,7 @@ class OpenTelemetryHookTest extends TestCase
         $api->clearHooks();
 
         // When
-        // simulates the composer autoload
-        require_once __DIR__ . '/../../src/_autoload.php';
+        $this->simulateAutoload();
 
         // Then
         $this->assertNotEmpty($api->getHooks());
@@ -38,5 +37,10 @@ class OpenTelemetryHookTest extends TestCase
         // Then
         $this->assertNotEmpty($api->getHooks());
         $this->assertInstanceOf(Hook::class, $api->getHooks()[0]);
+    }
+
+    private function simulateAutoload(): void
+    {
+        require_once __DIR__ . '/../../src/_autoload.php';
     }
 }

--- a/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
+++ b/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
@@ -9,9 +9,6 @@ use OpenFeature\Hooks\OpenTelemetry\Test\TestCase;
 use OpenFeature\OpenFeatureAPI;
 use OpenFeature\interfaces\hooks\Hook;
 
-use function phpversion;
-use function preg_match;
-
 class OpenTelemetryHookTest extends TestCase
 {
     public function testIsRegisteredAutomatically(): void

--- a/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
+++ b/hooks/OpenTelemetry/tests/integration/OpenTelemetryHookTest.php
@@ -25,7 +25,7 @@ class OpenTelemetryHookTest extends TestCase
 
         // Then
 
-        $this->assertCount($this->isAutoloadSupported() ? 1 : 0, $api->getHooks());
+        $this->assertCount(1, $api->getHooks());
         $this->assertInstanceOf(Hook::class, $api->getHooks()[0]);
     }
 
@@ -39,23 +39,12 @@ class OpenTelemetryHookTest extends TestCase
         OpenTelemetryHook::register();
 
         // Then
-        $this->assertNotEmpty($api->getHooks());
+        $this->assertCount(1, $api->getHooks());
         $this->assertInstanceOf(Hook::class, $api->getHooks()[0]);
     }
 
     private function simulateAutoload(): void
     {
         require __DIR__ . '/../../src/_autoload.php';
-    }
-
-    private function isAutoloadSupported(): bool
-    {
-        $version = phpversion();
-
-        if (!$version) {
-            return false;
-        }
-
-        return preg_match('/8\..+/', $version) === 1;
     }
 }

--- a/providers/CloudBees/composer.json
+++ b/providers/CloudBees/composer.json
@@ -24,7 +24,7 @@
   ],
   "require": {
     "php": "^7.4 || ^8",
-    "open-feature/sdk": "^1.0.0",
+    "open-feature/sdk": "^1.2.0",
     "rollout/rox": "^5.0"
   },
   "require-dev": {

--- a/providers/CloudBees/examples/CloudBees/composer.json
+++ b/providers/CloudBees/examples/CloudBees/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "open-feature/sdk": "^0.0.5",
+        "open-feature/sdk": "^1.2.0",
         "open-feature/cloudbees-provider": "^0.0.1"
     }
 }

--- a/providers/Flagd/examples/Grpc/composer.json
+++ b/providers/Flagd/examples/Grpc/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "open-feature/sdk": "^0.0.5",
+        "open-feature/sdk": "^1.2.0",
         "monolog/monolog": "^2.8"
     }
 }

--- a/providers/Flagd/examples/Http/composer.json
+++ b/providers/Flagd/examples/Http/composer.json
@@ -15,6 +15,6 @@
         }
     ],
     "require": {
-        "open-feature/sdk": "^0.0.5"
+        "open-feature/sdk": "^1.2.0"
     }
 }

--- a/providers/Split/composer.json
+++ b/providers/Split/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": "^7.4 || ^8",
-    "open-feature/sdk": "^1.1.0",
+    "open-feature/sdk": "^1.2.0",
     "splitsoftware/split-sdk-php": "^7.1"
   },
   "require-dev": {

--- a/providers/Split/examples/SplitSDK/composer.json
+++ b/providers/Split/examples/SplitSDK/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "open-feature/sdk": "^0.0.5",
+        "open-feature/sdk": "^1.2.0",
         "open-feature/split-provider": "^0.0.1"
     }
 }


### PR DESCRIPTION
## This PR

- autoload registration of otel hook

### Related Issues


### Notes

Projects that installed the `open-feature/otel-hook` package no longer need to take any action to register the hook, it will automatically be registered at startup by Composer.

If instrumentation has not been performed for OTel, this will automatically utilize a no-op tracer per their docs and has very little overhead.

### Follow-up Tasks

Docs

### How to test

Given the open-feature/otel-hook package is installed
When the application is run
Then the OTel hook for OpenFeature is registered in the API hooks

