### PR TITLE
ci: disable fail-fast behavior

### DIFF
--- a/.github/workflows/php-ci.yaml
+++ b/.github/workflows/php-ci.yaml
@@ -20,6 +20,7 @@ jobs:
           - providers/Flagd
           - providers/Split
           - providers/CloudBees
+      fail-fast: false
 
     # todo exclude some matrix combinations based on php version requirements
     # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations


### PR DESCRIPTION
## This PR

there are scenarios where some providers may fail and it may be entirely on downstream dependencies or configurations unrelated to a PR. this change allows a full PR's CI jobs to execute regardless of a failure in another job.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes

Nothing really that special, just allows us to gather more insight into jobs that don't fail.

### Follow-up Tasks


### How to test

Do all CI stages run without being cancelled?

