### PR TITLE
ci: disable CloudBees CI

### DIFF
--- a/.github/workflows/php-ci.yaml
+++ b/.github/workflows/php-ci.yaml
@@ -19,7 +19,7 @@ jobs:
           - hooks/Validators
           - providers/Flagd
           - providers/Split
-          - providers/CloudBees
+          # - providers/CloudBees
       fail-fast: false
 
     # todo exclude some matrix combinations based on php version requirements


### PR DESCRIPTION
## This PR

- disables CloudBees CI jobs

### Related Issues

### Notes

### Follow-up Tasks

revert after issue is resolved (#91)

### How to test

All CI jobs pass (since the currently failing ones won't run)

