### PR TITLE
fix: declaration for provider name

### DIFF
--- a/providers/CloudBees/src/CloudBeesProvider.php
+++ b/providers/CloudBees/src/CloudBeesProvider.php
@@ -26,7 +26,7 @@ use function is_null;
 
 class CloudBeesProvider extends AbstractProvider implements Provider
 {
-    protected const NAME = 'CloudBeesProvider';
+    protected static string $NAME = 'CloudBeesProvider';
 
     private static ?CloudBeesProvider $instance = null;
 

--- a/providers/CloudBees/tests/integration/CloudBeesProviderTest.php
+++ b/providers/CloudBees/tests/integration/CloudBeesProviderTest.php
@@ -42,6 +42,7 @@ class CloudBeesProviderTest extends TestCase
         $this->assertNotNull($instance);
         $this->assertInstanceOf(CloudBeesProvider::class, $instance);
         $this->assertInstanceOf(Provider::class, $instance);
+        $this->assertEquals('CloudBeesProvider', $instance->getMetadata()->getName());
     }
 
     public function testCanResolveBool(): void

--- a/providers/Flagd/src/FlagdProvider.php
+++ b/providers/Flagd/src/FlagdProvider.php
@@ -16,7 +16,7 @@ use OpenFeature\interfaces\provider\ResolutionDetails;
 
 class FlagdProvider extends AbstractProvider implements Provider
 {
-    protected const NAME = 'FlagdProvider';
+    protected static string $NAME = 'FlagdProvider';
 
     private IConfig $config;
 

--- a/providers/Flagd/tests/unit/FlagdProviderTest.php
+++ b/providers/Flagd/tests/unit/FlagdProviderTest.php
@@ -35,6 +35,7 @@ class FlagdProviderTest extends TestCase
         // Then
         $this->assertNotNull($instance);
         $this->assertInstanceOf(Provider::class, $instance);
+        $this->assertEquals('FlagdProvider', $instance->getMetadata()->getName());
     }
 
     public function testCanInstantiateHttpWithConfigObject(): void

--- a/providers/Split/src/SplitProvider.php
+++ b/providers/Split/src/SplitProvider.php
@@ -31,7 +31,7 @@ use function is_null;
 
 class SplitProvider extends AbstractProvider implements Provider
 {
-    protected const NAME = 'SplitProvider';
+    protected static string $NAME = 'SplitProvider';
 
     /**
      * The Split factory will only be created one time

--- a/providers/Split/tests/unit/SplitProviderTest.php
+++ b/providers/Split/tests/unit/SplitProviderTest.php
@@ -27,6 +27,7 @@ class SplitProviderTest extends TestCase
         // Then
         $this->assertNotNull($instance);
         $this->assertInstanceOf(Provider::class, $instance);
+        $this->assertEquals('SplitProvider', $instance->getMetadata()->getName());
     }
 
     private function getPathToValidSplitFile(): string


### PR DESCRIPTION
The implementation is not fulfilling the abstraction definition:
https://github.com/open-feature/php-sdk/blob/4e25be68937dc4ec405366cb6ba726f66fc0e5c8/src/implementation/provider/AbstractProvider.php#L19

```
protected static string $NAME = 'AbstractProvider';
```

The implementation is pointing not to a property but to a constant.

```
protected const NAME = 'SplitProvider';
```

This is leading to `getMetadata` method in the implementation to return all the time "AbstractProvider" value

**Reproducing the issues:**
```
<?php
abstract class AbstractProvider {
  protected static string $NAME = 'AbstractProvider';
  
  public function getMetadata()
  {
      return static::$NAME;
  }
}

class SplitProvider extends AbstractProvider
{
    protected const NAME = 'SplitProvider';
}

class FlagdProvider extends AbstractProvider
{
    protected const NAME = 'FlagdProvider';
}

$splitProvider = new SplitProvider();
var_dump($splitProvider->getMetadata());


$flagDProvider = new FlagdProvider();
var_dump($flagDProvider->getMetadata());
?>
```