### PR TITLE
feat: FlagsmithProvider

### DIFF
--- a/.github/workflows/php-ci.yaml
+++ b/.github/workflows/php-ci.yaml
@@ -14,13 +14,14 @@ jobs:
         operating-system: [ubuntu-latest]
         php-version: ['8.0', '8.1', '8.2']
         project-dir:
-          - hooks/OpenTelemetry
           - hooks/DDTrace
+          - hooks/OpenTelemetry
           - hooks/Validators
-          - providers/Flagd
-          - providers/Split
-          - providers/GoFeatureFlag
           # - providers/CloudBees
+          - providers/Flagd
+          - providers/Flagsmith
+          - providers/GoFeatureFlag
+          - providers/Split
       fail-fast: false
 
     # todo exclude some matrix combinations based on php version requirements

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -24,6 +24,7 @@ jobs:
           - [hook, validators, Validators]
           - [provider, cloudbees, CloudBees]
           - [provider, flagd, Flagd]
+          - [provider, flagsmith, Flagsmith]
           - [provider, split, Split]
           - [provider, go-feature-flag, GoFeatureFlag]
     steps:

--- a/providers/Flagsmith/.gitattributes
+++ b/providers/Flagsmith/.gitattributes
@@ -1,0 +1,15 @@
+/.editorconfig              export-ignore
+/.gitattributes             export-ignore
+/.github/                   export-ignore
+/.gitignore                 export-ignore
+/.readthedocs.yml           export-ignore
+/build/                     export-ignore
+/CHANGELOG.md               export-ignore
+/phpcs.xml.dist             export-ignore
+/phpstan.neon.dist          export-ignore
+/phpunit.xml.dist           export-ignore
+/psalm-baseline.xml         export-ignore
+/psalm.xml                  export-ignore
+/tests/                     export-ignore
+
+*                           text=auto

--- a/providers/Flagsmith/.gitignore
+++ b/providers/Flagsmith/.gitignore
@@ -1,0 +1,3 @@
+/build
+/composer.lock
+/vendor

--- a/providers/Flagsmith/CHANGELOG.md
+++ b/providers/Flagsmith/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/providers/Flagsmith/README.md
+++ b/providers/Flagsmith/README.md
@@ -32,7 +32,7 @@ OpenFeatureAPI::setProvider(new FlagsmithProvider($flagsmith));
 
 ### PHP Versioning
 
-This library targets PHP version and newer. As long as you have any compatible version of PHP on your system you should be able to utilize the OpenFeature SDK.
+This library targets PHP 8.1 and above. As long as you have a compatible version of PHP on your system, you should be able to utilize the OpenFeature SDK.
 
 This package also has a `.tool-versions` file for use with PHP version managers like `asdf`.
 

--- a/providers/Flagsmith/README.md
+++ b/providers/Flagsmith/README.md
@@ -1,0 +1,47 @@
+# OpenFeature Flagsmith Provider for PHP
+
+[![a](https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack)](https://cloud-native.slack.com/archives/C0344AANLA1)
+[![Latest Stable Version](http://poser.pugx.org/open-feature/flagsmith-provider/v)](https://packagist.org/packages/open-feature/flagsmith-provider)
+[![Total Downloads](http://poser.pugx.org/open-feature/flagsmith-provider/downloads)](https://packagist.org/packages/open-feature/flagsmith-provider)
+![PHP 8.0+](https://img.shields.io/badge/php->=8.0-blue.svg)
+[![License](http://poser.pugx.org/open-feature/flagsmith-provider/license)](https://packagist.org/packages/open-feature/flagsmith-provider)
+
+## Overview
+
+Flagsmith provides an all-in-one platform for developing, implementing, and managing your feature flags. This repository and package provides the client side code for interacting with it via the OpenFeature PHP SDK.
+
+This package also builds on various PSRs (PHP Standards Recommendations) such as the Logger interfaces (PSR-3) and the Basic and Extended Coding Standards (PSR-1 and PSR-12).
+
+## Installation
+
+```sh
+composer require open-feature/flagsmith-provider
+```
+
+## Usage
+
+The `FlagsmithProvider` constructor takes a configured Flagsmith client as its only argument:
+
+```php
+$flagsmith = new Flagsmith\Flagsmith('YOUR_FLAGSMITH_API_KEY');
+
+OpenFeatureAPI::setProvider(new FlagsmithProvider($flagsmith));
+```
+
+## Development
+
+### PHP Versioning
+
+This library targets PHP version and newer. As long as you have any compatible version of PHP on your system you should be able to utilize the OpenFeature SDK.
+
+This package also has a `.tool-versions` file for use with PHP version managers like `asdf`.
+
+### Installation and Dependencies
+
+Install dependencies with `composer install`.
+
+We value having as few runtime dependencies as possible. The addition of any dependencies requires careful consideration and review.
+
+### Testing
+
+Run tests with `composer run test`.

--- a/providers/Flagsmith/composer.json
+++ b/providers/Flagsmith/composer.json
@@ -22,8 +22,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "ext-json": "*",
-    "flagsmith/flagsmith-php-client": "^4.1",
+    "flagsmith/flagsmith-php-client": "^4.5.1",
     "open-feature/sdk": "^2.0"
   },
   "require-dev": {

--- a/providers/Flagsmith/composer.json
+++ b/providers/Flagsmith/composer.json
@@ -81,8 +81,8 @@
       "@dev:analyze:phpstan",
       "@dev:analyze:psalm"
     ],
-    "dev:analyze:phpstan": "phpstan analyse --ansi --debug --memory-limit=512M",
-    "dev:analyze:psalm": "psalm",
+    "dev:analyze:phpstan": "@php vendor/bin/phpstan analyse --ansi --debug --memory-limit=512M",
+    "dev:analyze:psalm": "@php vendor/bin/psalm",
     "dev:build:clean": "git clean -fX build/",
     "dev:grpc": [
       "@dev:grpc:init",
@@ -96,19 +96,19 @@
       "@dev:lint:syntax",
       "@dev:lint:style"
     ],
-    "dev:lint:fix": "phpcbf",
-    "dev:lint:style": "phpcs --colors",
-    "dev:lint:syntax": "parallel-lint --colors src/ tests/",
+    "dev:lint:fix": "@php vendor/bin/phpcbf",
+    "dev:lint:style": "@php vendor/bin/phpcs --colors",
+    "dev:lint:syntax": "@php vendor/bin/parallel-lint --colors src/ tests/",
     "dev:test": [
       "@dev:lint",
       "@dev:analyze",
       "@dev:test:unit",
       "@dev:test:integration"
     ],
-    "dev:test:coverage:ci": "phpunit --colors=always --coverage-text --coverage-clover build/coverage/clover.xml --coverage-cobertura build/coverage/cobertura.xml --coverage-crap4j build/coverage/crap4j.xml --coverage-xml build/coverage/coverage-xml --log-junit build/junit.xml",
-    "dev:test:coverage:html": "phpunit --colors=always --coverage-html build/coverage/coverage-html/",
-    "dev:test:unit": "phpunit --colors=always --testdox",
-    "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
+    "dev:test:coverage:ci": "@php vendor/bin/phpunit --colors=always --coverage-text --coverage-clover build/coverage/clover.xml --coverage-cobertura build/coverage/cobertura.xml --coverage-crap4j build/coverage/crap4j.xml --coverage-xml build/coverage/coverage-xml --log-junit build/junit.xml",
+    "dev:test:coverage:html": "@php vendor/bin/phpunit --colors=always --coverage-html build/coverage/coverage-html/",
+    "dev:test:unit": "@php vendor/bin/phpunit --colors=always --testdox",
+    "dev:test:unit:debug": "@php vendor/bin/phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
     "dev:test:unit:setup": "echo 'Setup for unit tests...'",
     "dev:test:unit:teardown": "echo 'Tore down unit tests...'",
     "dev:test:integration:setup": "echo 'Setup for integration tests...'",

--- a/providers/Flagsmith/composer.json
+++ b/providers/Flagsmith/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": "^8",
+    "php": "^8.1",
     "ext-json": "*",
     "flagsmith/flagsmith-php-client": "^4.1",
     "open-feature/sdk": "^2.0"

--- a/providers/Flagsmith/composer.json
+++ b/providers/Flagsmith/composer.json
@@ -22,6 +22,7 @@
   ],
   "require": {
     "php": "^8",
+    "ext-json": "*",
     "flagsmith/flagsmith-php-client": "^4.1",
     "open-feature/sdk": "^2.0",
     "php-http/httplug": "^2.3.0",

--- a/providers/Flagsmith/composer.json
+++ b/providers/Flagsmith/composer.json
@@ -1,0 +1,138 @@
+{
+  "name": "open-feature/flagsmith-provider",
+  "description": "The Flagsmith provider package for open-feature",
+  "license": "Apache-2.0",
+  "type": "library",
+  "keywords": [
+    "featureflags",
+    "featureflagging",
+    "openfeature",
+    "flagsmith",
+    "provider"
+  ],
+  "authors": [
+    {
+      "name": "OpenFeature PHP Maintainers",
+      "homepage": "https://github.com/orgs/open-feature/teams/php-maintainer"
+    },
+    {
+      "name": "open-feature/php-sdk-contrib Contributors",
+      "homepage": "https://github.com/open-feature/php-sdk-contrib/graphs/contributors"
+    }
+  ],
+  "require": {
+    "php": "^8",
+    "flagsmith/flagsmith-php-client": "^4.1",
+    "open-feature/sdk": "^2.0",
+    "php-http/httplug": "^2.3.0",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0",
+    "psr/http-message": "^2.0",
+    "psr/log": "^2.0 || ^3.0"
+  },
+  "require-dev": {
+    "ergebnis/composer-normalize": "^2.25",
+    "friendsofphp/php-cs-fixer": "^3.13",
+    "hamcrest/hamcrest-php": "^2.0",
+    "mdwheele/zalgo": "^0.3.1",
+    "mockery/mockery": "^1.5",
+    "phan/phan": "^5.4",
+    "php-parallel-lint/php-console-highlighter": "^1.0",
+    "php-parallel-lint/php-parallel-lint": "^1.3",
+    "phpstan/extension-installer": "^1.1",
+    "phpstan/phpstan": "~1.10.0",
+    "phpstan/phpstan-mockery": "^1.0",
+    "phpstan/phpstan-phpunit": "^1.1",
+    "psalm/plugin-mockery": "^0.11.0",
+    "psalm/plugin-phpunit": "^0.18.0",
+    "ramsey/coding-standard": "^2.0.3",
+    "ramsey/composer-repl": "^1.4",
+    "ramsey/conventional-commits": "^1.3",
+    "roave/security-advisories": "dev-latest",
+    "spatie/phpunit-snapshot-assertions": "^4.2",
+    "vimeo/psalm": "~4.30.0"
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "autoload": {
+    "psr-4": {
+      "OpenFeature\\Providers\\Flagsmith\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "OpenFeature\\Providers\\Flagsmith\\Test\\": "tests/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "phpstan/extension-installer": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "ergebnis/composer-normalize": true,
+      "captainhook/plugin-composer": true,
+      "ramsey/composer-repl": true,
+      "php-http/discovery": false
+    },
+    "lock": false,
+    "sort-packages": true
+  },
+  "extra": {
+    "captainhook": {
+      "force-install": false
+    }
+  },
+  "scripts": {
+    "dev:analyze": [
+      "@dev:analyze:phpstan",
+      "@dev:analyze:psalm"
+    ],
+    "dev:analyze:phpstan": "phpstan analyse --ansi --debug --memory-limit=512M",
+    "dev:analyze:psalm": "psalm",
+    "dev:build:clean": "git clean -fX build/",
+    "dev:grpc": [
+      "@dev:grpc:init",
+      "@dev:grpc:generate",
+      "@dev:grpc:stage"
+    ],
+    "dev:grpc:generate": "export GOPATH=\"$(pwd)/schemas/vendor\" && pushd schemas && make gen-php && popd",
+    "dev:grpc:init": "git submodule update --recursive",
+    "dev:grpc:stage": "git add --force ./proto",
+    "dev:lint": [
+      "@dev:lint:syntax",
+      "@dev:lint:style"
+    ],
+    "dev:lint:fix": "phpcbf",
+    "dev:lint:style": "phpcs --colors",
+    "dev:lint:syntax": "parallel-lint --colors src/ tests/",
+    "dev:test": [
+      "@dev:lint",
+      "@dev:analyze",
+      "@dev:test:unit",
+      "@dev:test:integration"
+    ],
+    "dev:test:coverage:ci": "phpunit --colors=always --coverage-text --coverage-clover build/coverage/clover.xml --coverage-cobertura build/coverage/cobertura.xml --coverage-crap4j build/coverage/crap4j.xml --coverage-xml build/coverage/coverage-xml --log-junit build/junit.xml",
+    "dev:test:coverage:html": "phpunit --colors=always --coverage-html build/coverage/coverage-html/",
+    "dev:test:unit": "phpunit --colors=always --testdox",
+    "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
+    "dev:test:unit:setup": "echo 'Setup for unit tests...'",
+    "dev:test:unit:teardown": "echo 'Tore down unit tests...'",
+    "dev:test:integration:setup": "echo 'Setup for integration tests...'",
+    "dev:test:integration:teardown": "echo 'Tore down integration tests...'",
+    "test": "@dev:test"
+  },
+  "scripts-descriptions": {
+    "dev:analyze": "Runs all static analysis checks.",
+    "dev:analyze:phpstan": "Runs the PHPStan static analyzer.",
+    "dev:analyze:psalm": "Runs the Psalm static analyzer.",
+    "dev:build:clean": "Cleans the build/ directory.",
+    "dev:lint": "Runs all linting checks.",
+    "dev:lint:fix": "Auto-fixes coding standards issues, if possible.",
+    "dev:lint:style": "Checks for coding standards issues.",
+    "dev:lint:syntax": "Checks for syntax errors.",
+    "dev:test": "Runs linting, static analysis, and unit tests.",
+    "dev:test:coverage:ci": "Runs unit tests and generates CI coverage reports.",
+    "dev:test:coverage:html": "Runs unit tests and generates HTML coverage report.",
+    "dev:test:unit": "Runs unit tests.",
+    "test": "Runs linting, static analysis, and unit tests."
+  }
+}

--- a/providers/Flagsmith/composer.json
+++ b/providers/Flagsmith/composer.json
@@ -24,12 +24,7 @@
     "php": "^8",
     "ext-json": "*",
     "flagsmith/flagsmith-php-client": "^4.1",
-    "open-feature/sdk": "^2.0",
-    "php-http/httplug": "^2.3.0",
-    "psr/http-client": "^1.0",
-    "psr/http-factory": "^1.0",
-    "psr/http-message": "^2.0",
-    "psr/log": "^2.0 || ^3.0"
+    "open-feature/sdk": "^2.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.25",

--- a/providers/Flagsmith/phpcs.xml.dist
+++ b/providers/Flagsmith/phpcs.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <file>./src</file>
+    <file>./tests</file>
+
+    <exclude-pattern>*/tests/fixtures/*</exclude-pattern>
+    <exclude-pattern>*/tests/*/fixtures/*</exclude-pattern>
+
+    <rule ref="Ramsey">
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousErrorNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
+
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+        <exclude name="Generic.Commenting.Todo.TaskFound"/>
+    </rule>
+
+</ruleset>

--- a/providers/Flagsmith/phpstan.neon.dist
+++ b/providers/Flagsmith/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+    tmpDir: ./build/cache/phpstan
+    level: max
+    paths:
+        - ./src
+        - ./tests
+    excludePaths:
+        - */tests/fixtures/*
+        - */tests/*/fixtures/*

--- a/providers/Flagsmith/phpunit.xml.dist
+++ b/providers/Flagsmith/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         cacheResultFile="./build/cache/phpunit.result.cache"
+         colors="true"
+         verbose="true">
+
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+
+    <php>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
+
+</phpunit>

--- a/providers/Flagsmith/psalm-baseline.xml
+++ b/providers/Flagsmith/psalm-baseline.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.9.5@0cfe565d0afbcd31eadcc281b9017b5692911661"/>

--- a/providers/Flagsmith/psalm.xml
+++ b/providers/Flagsmith/psalm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<psalm xmlns="https://getpsalm.org/schema/config"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+       errorLevel="1"
+       cacheDirectory="./build/cache/psalm"
+       errorBaseline="./psalm-baseline.xml">
+
+    <projectFiles>
+        <directory name="./src"/>
+        <ignoreFiles>
+            <directory name="./tests"/>
+            <directory name="./vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+</psalm>

--- a/providers/Flagsmith/src/FlagsmithProvider.php
+++ b/providers/Flagsmith/src/FlagsmithProvider.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Providers\Flagsmith;
+
+use Flagsmith\Exceptions\FlagsmithThrowable;
+use Flagsmith\Flagsmith;
+use Flagsmith\Models\Flags;
+use OpenFeature\implementation\provider\AbstractProvider;
+use OpenFeature\implementation\provider\ResolutionDetailsBuilder;
+use OpenFeature\implementation\provider\ResolutionDetailsFactory;
+use OpenFeature\implementation\provider\ResolutionError;
+use OpenFeature\interfaces\flags\EvaluationContext;
+use OpenFeature\interfaces\provider\ErrorCode;
+use OpenFeature\interfaces\provider\Provider;
+use OpenFeature\interfaces\provider\ResolutionDetails;
+
+use function is_null;
+
+class FlagsmithProvider extends AbstractProvider implements Provider
+{
+    protected static string $NAME = 'FlagsmithProvider';
+
+    public function __construct(
+        private Flagsmith $flagsmith,
+    ) {
+    }
+
+    public function resolveBooleanValue(string $flagKey, bool $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
+    {
+        try {
+            return ResolutionDetailsFactory::fromSuccess(
+                $this->contextualFlagStore($context)->getFlag($flagKey)->getEnabled(),
+            );
+        } catch (FlagsmithThrowable $throwable) {
+            return (new ResolutionDetailsBuilder())
+                ->withValue($defaultValue)
+                ->withError(
+                    new ResolutionError(ErrorCode::GENERAL(), $throwable->getMessage()),
+                )->build();
+        }
+    }
+
+    public function resolveStringValue(string $flagKey, string $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
+    {
+        $resolutionDetails = (new ResolutionDetailsBuilder())->build();
+
+        try {
+            $resolutionDetails->setValue(
+                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
+            );
+        } catch (FlagsmithThrowable) {
+            $resolutionDetails->setValue($defaultValue);
+        }
+
+        return $resolutionDetails;
+    }
+
+    public function resolveIntegerValue(string $flagKey, int $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
+    {
+        $resolutionDetails = (new ResolutionDetailsBuilder())->build();
+
+        try {
+            $resolutionDetails->setValue(
+                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
+            );
+        } catch (FlagsmithThrowable) {
+            $resolutionDetails->setValue($defaultValue);
+        }
+
+        return $resolutionDetails;
+    }
+
+    public function resolveFloatValue(string $flagKey, float $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
+    {
+        $resolutionDetails = (new ResolutionDetailsBuilder())->build();
+
+        try {
+            $resolutionDetails->setValue(
+                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
+            );
+        } catch (FlagsmithThrowable) {
+            $resolutionDetails->setValue($defaultValue);
+        }
+
+        return $resolutionDetails;
+    }
+
+    public function resolveObjectValue(string $flagKey, mixed $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
+    {
+        $builder = new ResolutionDetailsBuilder();
+
+        try {
+            $builder->withValue(
+                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
+            );
+        } catch (FlagsmithThrowable $throwable) {
+            $builder->withValue($defaultValue);
+            $builder->withError(
+                new ResolutionError(ErrorCode::GENERAL(), $throwable->getMessage()),
+            );
+        }
+
+        return $builder->build();
+    }
+
+    private function contextualFlagStore(?EvaluationContext $context = null): Flags
+    {
+        if ($context && !is_null($identifier = $context->getTargetingKey())) {
+            return $this->flagsmith->getIdentityFlags($identifier, (object) $context->getAttributes()->toArray());
+        }
+
+        return $this->flagsmith->getEnvironmentFlags();
+    }
+}

--- a/providers/Flagsmith/src/FlagsmithProvider.php
+++ b/providers/Flagsmith/src/FlagsmithProvider.php
@@ -19,7 +19,11 @@ use OpenFeature\interfaces\provider\Provider;
 use OpenFeature\interfaces\provider\Reason;
 use OpenFeature\interfaces\provider\ResolutionDetails;
 
+use function is_array;
 use function is_null;
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
 
 class FlagsmithProvider extends AbstractProvider implements Provider
 {
@@ -77,7 +81,7 @@ class FlagsmithProvider extends AbstractProvider implements Provider
             }
 
             $builder->withValue($value);
-        } catch (JsonException|InvalidArgumentException $exception) {
+        } catch (JsonException | InvalidArgumentException $exception) {
             $builder
                 ->withValue($defaultValue)
                 ->withError(

--- a/providers/Flagsmith/src/FlagsmithProvider.php
+++ b/providers/Flagsmith/src/FlagsmithProvider.php
@@ -44,56 +44,33 @@ class FlagsmithProvider extends AbstractProvider implements Provider
 
     public function resolveStringValue(string $flagKey, string $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
     {
-        $resolutionDetails = (new ResolutionDetailsBuilder())->build();
-
-        try {
-            $resolutionDetails->setValue(
-                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
-            );
-        } catch (FlagsmithThrowable) {
-            $resolutionDetails->setValue($defaultValue);
-        }
-
-        return $resolutionDetails;
+        return $this->resolve($flagKey, $defaultValue, $context);
     }
 
     public function resolveIntegerValue(string $flagKey, int $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
     {
-        $resolutionDetails = (new ResolutionDetailsBuilder())->build();
-
-        try {
-            $resolutionDetails->setValue(
-                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
-            );
-        } catch (FlagsmithThrowable) {
-            $resolutionDetails->setValue($defaultValue);
-        }
-
-        return $resolutionDetails;
+        return $this->resolve($flagKey, $defaultValue, $context);
     }
 
     public function resolveFloatValue(string $flagKey, float $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
     {
-        $resolutionDetails = (new ResolutionDetailsBuilder())->build();
-
-        try {
-            $resolutionDetails->setValue(
-                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
-            );
-        } catch (FlagsmithThrowable) {
-            $resolutionDetails->setValue($defaultValue);
-        }
-
-        return $resolutionDetails;
+        return $this->resolve($flagKey, $defaultValue, $context);
     }
 
     public function resolveObjectValue(string $flagKey, mixed $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
     {
+        return $this->resolve($flagKey, $defaultValue, $context);
+    }
+
+    protected function resolve(string $flagKey, mixed $defaultValue, ?EvaluationContext $context = null): ResolutionDetails
+    {
         $builder = new ResolutionDetailsBuilder();
 
         try {
+            $flag = $this->contextualFlagStore($context)->getFlag($flagKey);
+
             $builder->withValue(
-                $this->contextualFlagStore($context)->getFlag($flagKey)->getValue(),
+                $flag->getEnabled() ? $flag->getValue() : $defaultValue,
             );
         } catch (FlagsmithThrowable $throwable) {
             $builder->withValue($defaultValue);
@@ -105,6 +82,9 @@ class FlagsmithProvider extends AbstractProvider implements Provider
         return $builder->build();
     }
 
+    /**
+     * @throws FlagsmithThrowable
+     */
     private function contextualFlagStore(?EvaluationContext $context = null): Flags
     {
         if ($context && !is_null($identifier = $context->getTargetingKey())) {

--- a/providers/Flagsmith/src/FlagsmithProvider.php
+++ b/providers/Flagsmith/src/FlagsmithProvider.php
@@ -20,6 +20,7 @@ use OpenFeature\interfaces\provider\Provider;
 use OpenFeature\interfaces\provider\Reason;
 use OpenFeature\interfaces\provider\ResolutionDetails;
 
+use function array_is_list;
 use function is_array;
 use function is_null;
 use function is_string;
@@ -79,7 +80,7 @@ class FlagsmithProvider extends AbstractProvider implements Provider
             }
 
             // Valid JSON document might not be an array, so error in this case.
-            if (!is_array($value)) {
+            if (!is_array($value) || array_is_list($value)) {
                 throw new InvalidArgumentException("Flag [$flagKey] value must be a JSON encoded array");
             }
 

--- a/providers/Flagsmith/src/FlagsmithProvider.php
+++ b/providers/Flagsmith/src/FlagsmithProvider.php
@@ -30,7 +30,7 @@ use const JSON_THROW_ON_ERROR;
 
 class FlagsmithProvider extends AbstractProvider implements Provider
 {
-    protected static string $NAME = 'FlagsmithProvider';
+    protected static string $NAME = 'Flagsmith';
 
     public function __construct(
         private Flagsmith $flagsmith,

--- a/providers/Flagsmith/tests/Fixtures/TestOfflineHandler.php
+++ b/providers/Flagsmith/tests/Fixtures/TestOfflineHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Providers\Flagsmith\Test\Fixtures;
+
+use Flagsmith\Engine\Environments\EnvironmentModel;
+use Flagsmith\Offline\IOfflineHandler;
+
+class TestOfflineHandler implements IOfflineHandler
+{
+    public function __construct(
+        private ?EnvironmentModel $environmentModel = null,
+    ) {
+
+    }
+
+    public function getEnvironment(): ?EnvironmentModel
+    {
+        return $this->environmentModel;
+    }
+}

--- a/providers/Flagsmith/tests/Fixtures/TestOfflineHandler.php
+++ b/providers/Flagsmith/tests/Fixtures/TestOfflineHandler.php
@@ -12,7 +12,6 @@ class TestOfflineHandler implements IOfflineHandler
     public function __construct(
         private ?EnvironmentModel $environmentModel = null,
     ) {
-
     }
 
     public function getEnvironment(): ?EnvironmentModel

--- a/providers/Flagsmith/tests/Fixtures/environments/boolean.json
+++ b/providers/Flagsmith/tests/Fixtures/environments/boolean.json
@@ -1,0 +1,67 @@
+{
+  "project": {
+    "name": "Test project",
+    "organisation": {
+      "feature_analytics": false,
+      "name": "Test Org",
+      "id": 1,
+      "persist_trait_data": true,
+      "stop_serving_flags": false
+    },
+    "id": 1,
+    "hide_disabled_flags": false
+  },
+  "segment_overrides": [],
+  "id": 1,
+  "feature_states": [
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": "some-value",
+      "id": 1,
+      "feature": {
+        "name": "some_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": true
+    },
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": "some-value",
+      "id": 1,
+      "feature": {
+        "name": "disabled_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": false
+    }
+  ],
+  "identity_overrides": [
+    {
+      "identifier": "overridden-id",
+      "identity_uuid": "0f21cde8-63c5-4e50-baca-87897fa6cd01",
+      "created_date": "2019-08-27T14:53:45.698555Z",
+      "updated_at": "2023-07-14 16:12:00.000000",
+      "environment_api_key": "B62qaMZNwfiqT76p38ggrQ",
+      "identity_features": [
+        {
+          "id": 1,
+          "feature": {
+            "id": 1,
+            "name": "some_feature",
+            "type": "STANDARD"
+          },
+          "featurestate_uuid": "1bddb9a5-7e59-42c6-9be9-625fa369749f",
+          "feature_state_value": "some-overridden-value",
+          "enabled": false,
+          "environment": 1,
+          "identity": null,
+          "feature_segment": null
+        }
+      ]
+    }
+  ]
+}

--- a/providers/Flagsmith/tests/Fixtures/environments/float.json
+++ b/providers/Flagsmith/tests/Fixtures/environments/float.json
@@ -1,0 +1,67 @@
+{
+  "project": {
+    "name": "Test project",
+    "organisation": {
+      "feature_analytics": false,
+      "name": "Test Org",
+      "id": 1,
+      "persist_trait_data": true,
+      "stop_serving_flags": false
+    },
+    "id": 1,
+    "hide_disabled_flags": false
+  },
+  "segment_overrides": [],
+  "id": 1,
+  "feature_states": [
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": 2.345,
+      "id": 1,
+      "feature": {
+        "name": "float_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": true
+    },
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": -1.0,
+      "id": 1,
+      "feature": {
+        "name": "disabled_float_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": false
+    }
+  ],
+  "identity_overrides": [
+    {
+      "identifier": "overridden-id",
+      "identity_uuid": "0f21cde8-63c5-4e50-baca-87897fa6cd01",
+      "created_date": "2019-08-27T14:53:45.698555Z",
+      "updated_at": "2023-07-14 16:12:00.000000",
+      "environment_api_key": "B62qaMZNwfiqT76p38ggrQ",
+      "identity_features": [
+        {
+          "id": 1,
+          "feature": {
+            "id": 1,
+            "name": "some_feature",
+            "type": "STANDARD"
+          },
+          "featurestate_uuid": "1bddb9a5-7e59-42c6-9be9-625fa369749f",
+          "feature_state_value": "some-overridden-value",
+          "enabled": false,
+          "environment": 1,
+          "identity": null,
+          "feature_segment": null
+        }
+      ]
+    }
+  ]
+}

--- a/providers/Flagsmith/tests/Fixtures/environments/integer.json
+++ b/providers/Flagsmith/tests/Fixtures/environments/integer.json
@@ -1,0 +1,67 @@
+{
+  "project": {
+    "name": "Test project",
+    "organisation": {
+      "feature_analytics": false,
+      "name": "Test Org",
+      "id": 1,
+      "persist_trait_data": true,
+      "stop_serving_flags": false
+    },
+    "id": 1,
+    "hide_disabled_flags": false
+  },
+  "segment_overrides": [],
+  "id": 1,
+  "feature_states": [
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": 2,
+      "id": 1,
+      "feature": {
+        "name": "integer_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": true
+    },
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": -1,
+      "id": 1,
+      "feature": {
+        "name": "disabled_integer_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": false
+    }
+  ],
+  "identity_overrides": [
+    {
+      "identifier": "overridden-id",
+      "identity_uuid": "0f21cde8-63c5-4e50-baca-87897fa6cd01",
+      "created_date": "2019-08-27T14:53:45.698555Z",
+      "updated_at": "2023-07-14 16:12:00.000000",
+      "environment_api_key": "B62qaMZNwfiqT76p38ggrQ",
+      "identity_features": [
+        {
+          "id": 1,
+          "feature": {
+            "id": 1,
+            "name": "some_feature",
+            "type": "STANDARD"
+          },
+          "featurestate_uuid": "1bddb9a5-7e59-42c6-9be9-625fa369749f",
+          "feature_state_value": "some-overridden-value",
+          "enabled": false,
+          "environment": 1,
+          "identity": null,
+          "feature_segment": null
+        }
+      ]
+    }
+  ]
+}

--- a/providers/Flagsmith/tests/Fixtures/environments/object.json
+++ b/providers/Flagsmith/tests/Fixtures/environments/object.json
@@ -1,0 +1,79 @@
+{
+  "project": {
+    "name": "Test project",
+    "organisation": {
+      "feature_analytics": false,
+      "name": "Test Org",
+      "id": 1,
+      "persist_trait_data": true,
+      "stop_serving_flags": false
+    },
+    "id": 1,
+    "hide_disabled_flags": false
+  },
+  "segment_overrides": [],
+  "id": 1,
+  "feature_states": [
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": "{\"key\":\"value\"}",
+      "id": 1,
+      "feature": {
+        "name": "object_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": true
+    },
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": "some-value",
+      "id": 1,
+      "feature": {
+        "name": "disabled_object_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": false
+    },
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": "[\"foo\",\"bar\"]",
+      "id": 1,
+      "feature": {
+        "name": "invalid_object_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": true
+    }
+  ],
+  "identity_overrides": [
+    {
+      "identifier": "overridden-id",
+      "identity_uuid": "0f21cde8-63c5-4e50-baca-87897fa6cd01",
+      "created_date": "2019-08-27T14:53:45.698555Z",
+      "updated_at": "2023-07-14 16:12:00.000000",
+      "environment_api_key": "B62qaMZNwfiqT76p38ggrQ",
+      "identity_features": [
+        {
+          "id": 1,
+          "feature": {
+            "id": 1,
+            "name": "some_feature",
+            "type": "STANDARD"
+          },
+          "featurestate_uuid": "1bddb9a5-7e59-42c6-9be9-625fa369749f",
+          "feature_state_value": "some-overridden-value",
+          "enabled": false,
+          "environment": 1,
+          "identity": null,
+          "feature_segment": null
+        }
+      ]
+    }
+  ]
+}

--- a/providers/Flagsmith/tests/Fixtures/environments/string.json
+++ b/providers/Flagsmith/tests/Fixtures/environments/string.json
@@ -1,0 +1,67 @@
+{
+  "project": {
+    "name": "Test project",
+    "organisation": {
+      "feature_analytics": false,
+      "name": "Test Org",
+      "id": 1,
+      "persist_trait_data": true,
+      "stop_serving_flags": false
+    },
+    "id": 1,
+    "hide_disabled_flags": false
+  },
+  "segment_overrides": [],
+  "id": 1,
+  "feature_states": [
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": "flag value",
+      "id": 1,
+      "feature": {
+        "name": "string_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": true
+    },
+    {
+      "multivariate_feature_state_values": [],
+      "feature_state_value": "some-value",
+      "id": 1,
+      "feature": {
+        "name": "disabled_string_feature",
+        "type": "STANDARD",
+        "id": 1
+      },
+      "segment_id": null,
+      "enabled": false
+    }
+  ],
+  "identity_overrides": [
+    {
+      "identifier": "overridden-id",
+      "identity_uuid": "0f21cde8-63c5-4e50-baca-87897fa6cd01",
+      "created_date": "2019-08-27T14:53:45.698555Z",
+      "updated_at": "2023-07-14 16:12:00.000000",
+      "environment_api_key": "B62qaMZNwfiqT76p38ggrQ",
+      "identity_features": [
+        {
+          "id": 1,
+          "feature": {
+            "id": 1,
+            "name": "some_feature",
+            "type": "STANDARD"
+          },
+          "featurestate_uuid": "1bddb9a5-7e59-42c6-9be9-625fa369749f",
+          "feature_state_value": "some-overridden-value",
+          "enabled": false,
+          "environment": 1,
+          "identity": null,
+          "feature_segment": null
+        }
+      ]
+    }
+  ]
+}

--- a/providers/Flagsmith/tests/TestCase.php
+++ b/providers/Flagsmith/tests/TestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Providers\Flagsmith\Test;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Spatie\Snapshots\MatchesSnapshots;
+
+/**
+ * A base test case for Common test functionality
+ */
+abstract class TestCase extends PHPUnitTestCase
+{
+    use MatchesSnapshots;
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * Configures and returns a mock object
+     *
+     * @param class-string<T> $class
+     * @param mixed ...$arguments
+     *
+     * @return T & MockInterface
+     *
+     * @template T
+     *
+     * phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    public function mockery(string $class, ...$arguments)
+    {
+        /** @var T & MockInterface $mock */
+        $mock = Mockery::mock($class, ...$arguments);
+
+        return $mock;
+    }
+}

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -4,24 +4,78 @@ declare(strict_types=1);
 
 namespace OpenFeature\Providers\Flagsmith\Test\Unit;
 
+use Flagsmith\Engine\Environments\EnvironmentModel;
 use Flagsmith\Flagsmith;
 use OpenFeature\Providers\Flagsmith\FlagsmithProvider;
 use OpenFeature\Providers\Flagsmith\Test\Fixtures\TestOfflineHandler;
 use OpenFeature\Providers\Flagsmith\Test\TestCase;
+use OpenFeature\interfaces\provider\ErrorCode;
 use OpenFeature\interfaces\provider\Provider;
+
+use function file_get_contents;
+use function json_decode;
 
 class FlagsmithProviderTest extends TestCase
 {
+    protected function buildProvider(string $environmentModelPath): Provider
+    {
+        /** @var string $encoded */
+        $encoded = file_get_contents($environmentModelPath);
+        $modelData = json_decode($encoded,);
+
+        // @phpstan-ignore-next-line EnvironmentModel::build() type-hint is string but implementation expects object
+        $offlineHandler = new TestOfflineHandler(EnvironmentModel::build($modelData));
+        $flagsmith = new Flagsmith('dummy-key', offlineMode: true, offlineHandler: $offlineHandler);
+
+        return new FlagsmithProvider($flagsmith);
+    }
+
     public function testCanBeInstantiated(): void
     {
         // Given
         $flagsmith = new Flagsmith('dummy-key', offlineMode: true, offlineHandler: new TestOfflineHandler());
 
         // When
-        $instance = new FlagsmithProvider($flagsmith);
+        $provider = new FlagsmithProvider($flagsmith);
 
         // Then
-        $this->assertNotNull($instance);
-        $this->assertInstanceOf(Provider::class, $instance);
+        $this->assertInstanceOf(Provider::class, $provider);
+    }
+
+    public function testBooleanResolutionWithEnabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/boolean.json');
+
+        // When
+        $resolutionDetails = $provider->resolveBooleanValue('some_feature', false);
+
+        // Then
+        $this->assertTrue($resolutionDetails->getValue());
+    }
+
+    public function testBooleanResolutionWithDisabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/boolean.json');
+
+        // When
+        $resolutionDetails = $provider->resolveBooleanValue('disabled_feature', true);
+
+        // Then
+        $this->assertFalse($resolutionDetails->getValue());
+    }
+
+    public function testBooleanResolutionWithDefaultValueFromFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/boolean.json');
+
+        // When
+        $resolutionDetails = $provider->resolveBooleanValue('missing_feature', false);
+
+        // Then
+        $this->assertFalse($resolutionDetails->getValue());
+        $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
     }
 }

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -11,6 +11,7 @@ use OpenFeature\Providers\Flagsmith\Test\Fixtures\TestOfflineHandler;
 use OpenFeature\Providers\Flagsmith\Test\TestCase;
 use OpenFeature\interfaces\provider\ErrorCode;
 use OpenFeature\interfaces\provider\Provider;
+use OpenFeature\interfaces\provider\Reason;
 
 use function file_get_contents;
 use function json_decode;
@@ -77,5 +78,43 @@ class FlagsmithProviderTest extends TestCase
         // Then
         $this->assertFalse($resolutionDetails->getValue());
         $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
+    }
+
+    public function testStringResolutionWithEnabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/string.json');
+
+        // When
+        $resolutionDetails = $provider->resolveStringValue('string_feature', 'default value');
+
+        // Then
+        $this->assertEquals('flag value', $resolutionDetails->getValue());
+    }
+
+    public function testStringResolutionWithDisabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/string.json');
+
+        // When
+        $resolutionDetails = $provider->resolveStringValue('disabled_string_feature', 'default value');
+
+        // Then
+        $this->assertEquals('default value', $resolutionDetails->getValue());
+    }
+
+    public function testStringResolutionWithMissingFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/string.json');
+
+        // When
+        $resolutionDetails = $provider->resolveStringValue('missing_string_feature', 'default value');
+
+        // Then
+        $this->assertEquals('default value', $resolutionDetails->getValue());
+        $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
+        $this->assertEquals(Reason::ERROR, $resolutionDetails->getReason());
     }
 }

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -5,30 +5,15 @@ declare(strict_types=1);
 namespace OpenFeature\Providers\Flagsmith\Test\Unit;
 
 use Flagsmith\Flagsmith;
-use OpenFeature\Providers\Flagsmith\Config\ConfigFactory;
-use OpenFeature\Providers\Flagsmith\Config\HttpConfig;
 use OpenFeature\Providers\Flagsmith\FlagsmithProvider;
 use OpenFeature\Providers\Flagsmith\Test\TestCase;
 use OpenFeature\interfaces\provider\Provider;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Http\Message\StreamInterface;
 
 class FlagsmithProviderTest extends TestCase
 {
     public function testCanBeInstantiated(): void
     {
         // Given
-        $config = [
-            'httpConfig' => [
-                'client' => $this->mockery(ClientInterface::class),
-                'requestFactory' => $this->mockery(RequestFactoryInterface::class),
-                'streamFactory' => $this->mockery(StreamFactoryInterface::class),
-            ],
-        ];
         $flagsmith = new Flagsmith('dummy-key');
 
         // When

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -6,6 +6,7 @@ namespace OpenFeature\Providers\Flagsmith\Test\Unit;
 
 use Flagsmith\Flagsmith;
 use OpenFeature\Providers\Flagsmith\FlagsmithProvider;
+use OpenFeature\Providers\Flagsmith\Test\Fixtures\TestOfflineHandler;
 use OpenFeature\Providers\Flagsmith\Test\TestCase;
 use OpenFeature\interfaces\provider\Provider;
 
@@ -14,7 +15,7 @@ class FlagsmithProviderTest extends TestCase
     public function testCanBeInstantiated(): void
     {
         // Given
-        $flagsmith = new Flagsmith('dummy-key');
+        $flagsmith = new Flagsmith('dummy-key', offlineMode: true, offlineHandler: new TestOfflineHandler());
 
         // When
         $instance = new FlagsmithProvider($flagsmith);

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -155,4 +155,42 @@ class FlagsmithProviderTest extends TestCase
         $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
         $this->assertEquals(Reason::ERROR, $resolutionDetails->getReason());
     }
+
+    public function testFloatResolutionWithEnabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/float.json');
+
+        // When
+        $resolutionDetails = $provider->resolveFloatValue('float_feature', 1.0);
+
+        // Then
+        $this->assertEquals(2.345, $resolutionDetails->getValue());
+    }
+
+    public function testFloatResolutionWithDisabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/float.json');
+
+        // When
+        $resolutionDetails = $provider->resolveFloatValue('disabled_float_feature', 9.99);
+
+        // Then
+        $this->assertEquals(9.99, $resolutionDetails->getValue());
+    }
+
+    public function testFloatResolutionWithMissingFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/float.json');
+
+        // When
+        $resolutionDetails = $provider->resolveFloatValue('missing_float_feature', 0.123);
+
+        // Then
+        $this->assertEquals(0.123, $resolutionDetails->getValue());
+        $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
+        $this->assertEquals(Reason::ERROR, $resolutionDetails->getReason());
+    }
 }

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -193,4 +193,52 @@ class FlagsmithProviderTest extends TestCase
         $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
         $this->assertEquals(Reason::ERROR, $resolutionDetails->getReason());
     }
+
+    public function testObjectResolutionWithEnabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/object.json');
+
+        // When
+        $resolutionDetails = $provider->resolveObjectValue('object_feature', ['a' => 'b']);
+
+        // Then
+        $this->assertEquals(['key' => 'value'], $resolutionDetails->getValue());
+    }
+
+    public function testObjectResolutionWithDisabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/object.json');
+
+        // When
+        $resolutionDetails = $provider->resolveObjectValue('disabled_object_feature', ['a' => 'b']);
+
+        // Then
+        $this->assertEquals(['a' => 'b'], $resolutionDetails->getValue());
+    }
+
+    public function testObjectResolutionWithMissingFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/object.json');
+
+        // When
+        $resolutionDetails = $provider->resolveObjectValue('missing_object_feature', ['c' => 3, 'p' => 'o']);
+
+        // Then
+        $this->assertEquals(['c' => 3, 'p' => 'o'], $resolutionDetails->getValue());
+    }
+
+    public function testObjectResolutionWithEnabledFlagWithInvalidValue(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/object.json');
+
+        // When
+        $resolutionDetails = $provider->resolveObjectValue('invalid_object_feature', ['default' => 'value']);
+
+        // Then
+        $this->assertEquals(['default' => 'value'], $resolutionDetails->getValue());
+    }
 }

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Providers\Flagsmith\Test\Unit;
+
+use Flagsmith\Flagsmith;
+use OpenFeature\Providers\Flagsmith\Config\ConfigFactory;
+use OpenFeature\Providers\Flagsmith\Config\HttpConfig;
+use OpenFeature\Providers\Flagsmith\FlagsmithProvider;
+use OpenFeature\Providers\Flagsmith\Test\TestCase;
+use OpenFeature\interfaces\provider\Provider;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+
+class FlagsmithProviderTest extends TestCase
+{
+    public function testCanBeInstantiated(): void
+    {
+        // Given
+        $config = [
+            'httpConfig' => [
+                'client' => $this->mockery(ClientInterface::class),
+                'requestFactory' => $this->mockery(RequestFactoryInterface::class),
+                'streamFactory' => $this->mockery(StreamFactoryInterface::class),
+            ],
+        ];
+        $flagsmith = new Flagsmith('dummy-key');
+
+        // When
+        $instance = new FlagsmithProvider($flagsmith);
+
+        // Then
+        $this->assertNotNull($instance);
+        $this->assertInstanceOf(Provider::class, $instance);
+    }
+}

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -22,7 +22,7 @@ class FlagsmithProviderTest extends TestCase
     {
         /** @var string $encoded */
         $encoded = file_get_contents($environmentModelPath);
-        $modelData = json_decode($encoded,);
+        $modelData = json_decode($encoded);
 
         // @phpstan-ignore-next-line EnvironmentModel::build() type-hint is string but implementation expects object
         $offlineHandler = new TestOfflineHandler(EnvironmentModel::build($modelData));

--- a/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
+++ b/providers/Flagsmith/tests/Unit/FlagsmithProviderTest.php
@@ -117,4 +117,42 @@ class FlagsmithProviderTest extends TestCase
         $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
         $this->assertEquals(Reason::ERROR, $resolutionDetails->getReason());
     }
+
+    public function testIntegerResolutionWithEnabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/integer.json');
+
+        // When
+        $resolutionDetails = $provider->resolveIntegerValue('integer_feature', 1);
+
+        // Then
+        $this->assertEquals(2, $resolutionDetails->getValue());
+    }
+
+    public function testIntegerResolutionWithDisabledFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/integer.json');
+
+        // When
+        $resolutionDetails = $provider->resolveIntegerValue('disabled_integer_feature', 456);
+
+        // Then
+        $this->assertEquals(456, $resolutionDetails->getValue());
+    }
+
+    public function testIntegerResolutionWithMissingFlag(): void
+    {
+        // Given
+        $provider = $this->buildProvider(__DIR__ . '/../Fixtures/environments/integer.json');
+
+        // When
+        $resolutionDetails = $provider->resolveIntegerValue('missing_integer_feature', 123);
+
+        // Then
+        $this->assertEquals(123, $resolutionDetails->getValue());
+        $this->assertEquals(ErrorCode::GENERAL(), $resolutionDetails->getError()?->getResolutionErrorCode());
+        $this->assertEquals(Reason::ERROR, $resolutionDetails->getReason());
+    }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds new package, `open-feature/flagsmith-provider`
  - implements `OpenFeature\interfaces\provider\Provider` interface for Flagsmith
  - depends on `flagsmith/flagsmith-php-client`

### Notes
<!-- any additional notes for this PR -->
 - opted for PHP 8.1+, given it is the oldest version [currently supported](https://www.php.net/supported-versions.php).

![image](https://github.com/user-attachments/assets/e162cda1-cc40-4fea-92f9-a9e1a85467b6)


### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
```php
$flagsmith = new Flagsmith\Flagsmith('YOUR_FLAGSMITH_API_KEY');

OpenFeatureAPI::setProvider(new FlagsmithProvider($flagsmith));
```

Run the tests with:
```bash
composer run dev:test
```

You should (hopefully) see the below output:
![image](https://github.com/user-attachments/assets/6d671108-81cc-4d2a-9c17-131d6a748076)


