### PR TITLE
feat: Support trailing dot in flagd host

### DIFF
--- a/providers/Flagd/src/config/Validator.php
+++ b/providers/Flagd/src/config/Validator.php
@@ -18,7 +18,7 @@ use function preg_match;
 
 class Validator
 {
-    private const VALID_HOST_REGEXP = '/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$/i';
+    private const VALID_HOST_REGEXP = '/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.*)+$/i';
     private const VALID_PORT_RANGE = [1, 65535];
     private const VALID_PROTOCOLS = ['grpc', 'http'];
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Allows hosts with a trailing dot, as they are perfectly valid and can significantly improve performance in certain scenarios.

The use-case is explained in this [blog post](https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html).

tl;dr: Adding a trailing dot to hosts like flagd.feature-flags.svc.local may positively impact performance and resource usage under the default kube-dns resolver settings with ndots:5.
