### PR TITLE
ci: run PHP CI workflow up to PHP 8.5

### DIFF
--- a/.github/workflows/php-ci.yaml
+++ b/.github/workflows/php-ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         project-dir:
           - hooks/OpenTelemetry
           - hooks/DDTrace


### PR DESCRIPTION
## This PR

- expands support of PHP CI workflows to include up to PHP 8.5

### Related Issues

### Notes

May require additional work to fully pass (executing e.g. PHPStan across multiple PHP versions requires handling of version variance)

### Follow-up Tasks

### How to test

CI-specific change. CI must pass before merge.

