### PR TITLE
fix(flagd): resolve default value for disabled flags on flagd v0.16+

### DIFF
--- a/providers/Flagd/src/http/FlagdResponseResolutionDetailsAdapter.php
+++ b/providers/Flagd/src/http/FlagdResponseResolutionDetailsAdapter.php
@@ -9,6 +9,7 @@ use OpenFeature\Providers\Flagd\common\ResponseCodeErrorCodeMap;
 use OpenFeature\implementation\provider\ResolutionDetailsBuilder;
 use OpenFeature\implementation\provider\ResolutionError;
 use OpenFeature\interfaces\provider\ErrorCode;
+use OpenFeature\interfaces\provider\Reason;
 use OpenFeature\interfaces\provider\ResolutionDetails;
 
 class FlagdResponseResolutionDetailsAdapter
@@ -21,6 +22,17 @@ class FlagdResponseResolutionDetailsAdapter
         return (new ResolutionDetailsBuilder())
             ->withValue($defaultValue)
             ->withError(new ResolutionError(ErrorCode::TYPE_MISMATCH()))
+            ->build();
+    }
+
+    /**
+     * @param mixed[]|bool|DateTime|float|int|string|null $defaultValue
+     */
+    public static function forDisabled(mixed $defaultValue): ResolutionDetails
+    {
+        return (new ResolutionDetailsBuilder())
+            ->withValue($defaultValue)
+            ->withReason(Reason::DISABLED)
             ->build();
     }
 

--- a/providers/Flagd/src/http/FlagdResponseValidator.php
+++ b/providers/Flagd/src/http/FlagdResponseValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenFeature\Providers\Flagd\http;
 
+use OpenFeature\interfaces\provider\Reason;
+
 use function is_null;
 
 class FlagdResponseValidator
@@ -14,6 +16,17 @@ class FlagdResponseValidator
     public static function isTypeMismatch(?array $response): bool
     {
         return is_null($response);
+    }
+
+    /**
+     * As of flagd v0.16, a disabled flag resolves successfully with reason=DISABLED
+     * and no value/variant, rather than an error response.
+     *
+     * @param mixed[] $response
+     */
+    public static function isDisabled(?array $response): bool
+    {
+        return isset($response['reason']) && $response['reason'] === Reason::DISABLED;
     }
 
     /**

--- a/providers/Flagd/src/http/HttpService.php
+++ b/providers/Flagd/src/http/HttpService.php
@@ -82,6 +82,10 @@ class HttpService implements ServiceInterface
             return FlagdResponseResolutionDetailsAdapter::forTypeMismatch($details);
         }
 
+        if (FlagdResponseValidator::isDisabled($details)) {
+            return FlagdResponseResolutionDetailsAdapter::forDisabled($defaultValue);
+        }
+
         if (FlagdResponseValidator::isErrorResponse($details)) {
             return FlagdResponseResolutionDetailsAdapter::forError($details, $defaultValue);
         }

--- a/providers/Flagd/tests/unit/FlagdProviderTest.php
+++ b/providers/Flagd/tests/unit/FlagdProviderTest.php
@@ -149,4 +149,54 @@ class FlagdProviderTest extends TestCase
         $this->assertEquals($expectedVariant, $actualDetails->getVariant());
         $this->assertEquals($expectedReason, $actualDetails->getReason());
     }
+
+    public function testResolvesDefaultValueWhenFlagIsDisabled(): void
+    {
+        // Given
+        $expectedValue = true;
+
+        $mockRequest = $this->mockery(RequestInterface::class);
+        $mockRequest->shouldReceive('withHeader')->andReturn($mockRequest);
+        $mockRequest->shouldReceive('withBody')->andReturn($mockRequest);
+
+        $mockRequestFactory = $this->mockery(RequestFactoryInterface::class);
+        $mockRequestFactory->shouldReceive('createRequest')->andReturn($mockRequest);
+
+        $mockStream = $this->mockery(StreamInterface::class);
+
+        $mockStreamFactory = $this->mockery(StreamFactoryInterface::class);
+        $mockStreamFactory->shouldReceive('createStream')->andReturn($mockStream);
+
+        $mockResponse = $this->mockery(ResponseInterface::class);
+        $mockResponse->shouldReceive('getBody->__toString')->andReturn('{
+            "reason":"DISABLED"
+        }');
+
+        $mockClient = $this->mockery(ClientInterface::class);
+        $mockClient->shouldReceive('sendRequest')->with($mockRequest)->andReturn($mockResponse);
+
+        /** @var ClientInterface $client */
+        $client = $mockClient;
+        /** @var RequestFactoryInterface $requestFactory */
+        $requestFactory = $mockRequestFactory;
+        /** @var StreamFactoryInterface $streamFactory */
+        $streamFactory = $mockStreamFactory;
+
+        $config = ConfigFactory::fromOptions(
+            'localhost',
+            8013,
+            'http',
+            true,
+            new HttpConfig($client, $requestFactory, $streamFactory),
+        );
+
+        // When
+        $provider = new FlagdProvider($config);
+        $actualDetails = $provider->resolveBooleanValue('any-key', $expectedValue, null);
+
+        // Then
+        $this->assertEquals($expectedValue, $actualDetails->getValue());
+        $this->assertEquals('DISABLED', $actualDetails->getReason());
+        $this->assertNull($actualDetails->getError());
+    }
 }


### PR DESCRIPTION
flagd v0.16 changed disabled-flag evaluation to return a successful response with reason=DISABLED and no value/variant, instead of an error. Without this change, the missing value fell through to the generic error path and providers on flagd v0.15 semantics relied on that error to surface the default.

Add FlagdResponseValidator::isDisabled() and
FlagdResponseResolutionDetailsAdapter::forDisabled() so a disabled flag resolves to the caller-supplied default with reason=DISABLED, matching the OpenFeature spec. flagd v0.15 behavior (error response, code=not_found) is unaffected since it has no reason field.

Refs: open-feature/flagd#1997

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

