### PR TITLE
fix(flagd): fall back to caller default for DISABLED flag evaluations

### DIFF
--- a/providers/Flagd/src/http/FlagdResponseResolutionDetailsAdapter.php
+++ b/providers/Flagd/src/http/FlagdResponseResolutionDetailsAdapter.php
@@ -52,6 +52,17 @@ class FlagdResponseResolutionDetailsAdapter
     }
 
     /**
+     * @param mixed[]|bool|DateTime|float|int|string|null $defaultValue
+     */
+    public static function forDisabled(mixed $defaultValue): ResolutionDetails
+    {
+        return (new ResolutionDetailsBuilder())
+            ->withValue($defaultValue)
+            ->withReason('DISABLED')
+            ->build();
+    }
+
+    /**
      * @param array{value: mixed[]|bool|DateTime|float|int|string|null, variant: ?string, reason: ?string} $response
      */
     public static function forSuccess(array $response): ResolutionDetails

--- a/providers/Flagd/src/http/FlagdResponseResolutionDetailsAdapter.php
+++ b/providers/Flagd/src/http/FlagdResponseResolutionDetailsAdapter.php
@@ -9,6 +9,7 @@ use OpenFeature\Providers\Flagd\common\ResponseCodeErrorCodeMap;
 use OpenFeature\implementation\provider\ResolutionDetailsBuilder;
 use OpenFeature\implementation\provider\ResolutionError;
 use OpenFeature\interfaces\provider\ErrorCode;
+use OpenFeature\interfaces\provider\Reason;
 use OpenFeature\interfaces\provider\ResolutionDetails;
 
 class FlagdResponseResolutionDetailsAdapter
@@ -58,7 +59,7 @@ class FlagdResponseResolutionDetailsAdapter
     {
         return (new ResolutionDetailsBuilder())
             ->withValue($defaultValue)
-            ->withReason('DISABLED')
+            ->withReason(Reason::DISABLED)
             ->build();
     }
 

--- a/providers/Flagd/src/http/HttpService.php
+++ b/providers/Flagd/src/http/HttpService.php
@@ -14,6 +14,7 @@ use OpenFeature\Providers\Flagd\service\ServiceInterface;
 use OpenFeature\implementation\errors\FlagValueTypeError;
 use OpenFeature\interfaces\flags\EvaluationContext;
 use OpenFeature\interfaces\flags\FlagValueType;
+use OpenFeature\interfaces\provider\Reason;
 use OpenFeature\interfaces\provider\ResolutionDetails;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -86,7 +87,7 @@ class HttpService implements ServiceInterface
             return FlagdResponseResolutionDetailsAdapter::forError($details, $defaultValue);
         }
 
-        if (($details['reason'] ?? null) === 'DISABLED' && !isset($details['variant'])) {
+        if (($details['reason'] ?? null) === Reason::DISABLED && ($details['variant'] ?? '') === '') {
             return FlagdResponseResolutionDetailsAdapter::forDisabled($defaultValue);
         }
 

--- a/providers/Flagd/src/http/HttpService.php
+++ b/providers/Flagd/src/http/HttpService.php
@@ -86,6 +86,10 @@ class HttpService implements ServiceInterface
             return FlagdResponseResolutionDetailsAdapter::forError($details, $defaultValue);
         }
 
+        if (($details['reason'] ?? null) === 'DISABLED' && !isset($details['variant'])) {
+            return FlagdResponseResolutionDetailsAdapter::forDisabled($defaultValue);
+        }
+
         if ($flagType === FlagValueType::INTEGER) {
             $this->mapIntegerInResponse($details);
         }

--- a/providers/Flagd/tests/unit/FlagdProviderTest.php
+++ b/providers/Flagd/tests/unit/FlagdProviderTest.php
@@ -9,6 +9,7 @@ use OpenFeature\Providers\Flagd\Test\TestCase;
 use OpenFeature\Providers\Flagd\config\ConfigFactory;
 use OpenFeature\Providers\Flagd\config\HttpConfig;
 use OpenFeature\interfaces\provider\Provider;
+use OpenFeature\interfaces\provider\Reason;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -153,7 +154,7 @@ class FlagdProviderTest extends TestCase
     public function testDisabledBooleanFlagFallsBackToCallerDefault(): void
     {
         // Given
-        $provider = $this->providerWithResponseBody('{"value":false,"reason":"DISABLED"}');
+        $provider = $this->providerWithResponseBody('{"value":false,"reason":"DISABLED","variant":"","metadata":{}}');
 
         // When
         $actualDetails = $provider->resolveBooleanValue('any-key', true, null);
@@ -161,13 +162,13 @@ class FlagdProviderTest extends TestCase
         // Then
         $this->assertTrue($actualDetails->getValue());
         $this->assertNull($actualDetails->getVariant());
-        $this->assertEquals('DISABLED', $actualDetails->getReason());
+        $this->assertEquals(Reason::DISABLED, $actualDetails->getReason());
     }
 
     public function testDisabledStringFlagFallsBackToCallerDefault(): void
     {
         // Given
-        $provider = $this->providerWithResponseBody('{"value":"","reason":"DISABLED"}');
+        $provider = $this->providerWithResponseBody('{"value":"","reason":"DISABLED","variant":"","metadata":{}}');
 
         // When
         $actualDetails = $provider->resolveStringValue('any-key', 'fallback', null);
@@ -175,13 +176,13 @@ class FlagdProviderTest extends TestCase
         // Then
         $this->assertEquals('fallback', $actualDetails->getValue());
         $this->assertNull($actualDetails->getVariant());
-        $this->assertEquals('DISABLED', $actualDetails->getReason());
+        $this->assertEquals(Reason::DISABLED, $actualDetails->getReason());
     }
 
     public function testDisabledIntegerFlagFallsBackToCallerDefault(): void
     {
         // Given
-        $provider = $this->providerWithResponseBody('{"value":0,"reason":"DISABLED"}');
+        $provider = $this->providerWithResponseBody('{"value":"0","reason":"DISABLED","variant":"","metadata":{}}');
 
         // When
         $actualDetails = $provider->resolveIntegerValue('any-key', 42, null);
@@ -189,13 +190,13 @@ class FlagdProviderTest extends TestCase
         // Then
         $this->assertEquals(42, $actualDetails->getValue());
         $this->assertNull($actualDetails->getVariant());
-        $this->assertEquals('DISABLED', $actualDetails->getReason());
+        $this->assertEquals(Reason::DISABLED, $actualDetails->getReason());
     }
 
     public function testDisabledFloatFlagFallsBackToCallerDefault(): void
     {
         // Given
-        $provider = $this->providerWithResponseBody('{"value":0.0,"reason":"DISABLED"}');
+        $provider = $this->providerWithResponseBody('{"value":0.0,"reason":"DISABLED","variant":"","metadata":{}}');
 
         // When
         $actualDetails = $provider->resolveFloatValue('any-key', 1.5, null);
@@ -203,13 +204,13 @@ class FlagdProviderTest extends TestCase
         // Then
         $this->assertEquals(1.5, $actualDetails->getValue());
         $this->assertNull($actualDetails->getVariant());
-        $this->assertEquals('DISABLED', $actualDetails->getReason());
+        $this->assertEquals(Reason::DISABLED, $actualDetails->getReason());
     }
 
     public function testDisabledObjectFlagFallsBackToCallerDefault(): void
     {
         // Given
-        $provider = $this->providerWithResponseBody('{"value":{},"reason":"DISABLED"}');
+        $provider = $this->providerWithResponseBody('{"value":{},"reason":"DISABLED","variant":"","metadata":{}}');
         $default = ['a' => 1];
 
         // When
@@ -218,7 +219,7 @@ class FlagdProviderTest extends TestCase
         // Then
         $this->assertEquals($default, $actualDetails->getValue());
         $this->assertNull($actualDetails->getVariant());
-        $this->assertEquals('DISABLED', $actualDetails->getReason());
+        $this->assertEquals(Reason::DISABLED, $actualDetails->getReason());
     }
 
     private function providerWithResponseBody(string $body): FlagdProvider

--- a/providers/Flagd/tests/unit/FlagdProviderTest.php
+++ b/providers/Flagd/tests/unit/FlagdProviderTest.php
@@ -149,4 +149,111 @@ class FlagdProviderTest extends TestCase
         $this->assertEquals($expectedVariant, $actualDetails->getVariant());
         $this->assertEquals($expectedReason, $actualDetails->getReason());
     }
+
+    public function testDisabledBooleanFlagFallsBackToCallerDefault(): void
+    {
+        // Given
+        $provider = $this->providerWithResponseBody('{"value":false,"reason":"DISABLED"}');
+
+        // When
+        $actualDetails = $provider->resolveBooleanValue('any-key', true, null);
+
+        // Then
+        $this->assertTrue($actualDetails->getValue());
+        $this->assertNull($actualDetails->getVariant());
+        $this->assertEquals('DISABLED', $actualDetails->getReason());
+    }
+
+    public function testDisabledStringFlagFallsBackToCallerDefault(): void
+    {
+        // Given
+        $provider = $this->providerWithResponseBody('{"value":"","reason":"DISABLED"}');
+
+        // When
+        $actualDetails = $provider->resolveStringValue('any-key', 'fallback', null);
+
+        // Then
+        $this->assertEquals('fallback', $actualDetails->getValue());
+        $this->assertNull($actualDetails->getVariant());
+        $this->assertEquals('DISABLED', $actualDetails->getReason());
+    }
+
+    public function testDisabledIntegerFlagFallsBackToCallerDefault(): void
+    {
+        // Given
+        $provider = $this->providerWithResponseBody('{"value":0,"reason":"DISABLED"}');
+
+        // When
+        $actualDetails = $provider->resolveIntegerValue('any-key', 42, null);
+
+        // Then
+        $this->assertEquals(42, $actualDetails->getValue());
+        $this->assertNull($actualDetails->getVariant());
+        $this->assertEquals('DISABLED', $actualDetails->getReason());
+    }
+
+    public function testDisabledFloatFlagFallsBackToCallerDefault(): void
+    {
+        // Given
+        $provider = $this->providerWithResponseBody('{"value":0.0,"reason":"DISABLED"}');
+
+        // When
+        $actualDetails = $provider->resolveFloatValue('any-key', 1.5, null);
+
+        // Then
+        $this->assertEquals(1.5, $actualDetails->getValue());
+        $this->assertNull($actualDetails->getVariant());
+        $this->assertEquals('DISABLED', $actualDetails->getReason());
+    }
+
+    public function testDisabledObjectFlagFallsBackToCallerDefault(): void
+    {
+        // Given
+        $provider = $this->providerWithResponseBody('{"value":{},"reason":"DISABLED"}');
+        $default = ['a' => 1];
+
+        // When
+        $actualDetails = $provider->resolveObjectValue('any-key', $default, null);
+
+        // Then
+        $this->assertEquals($default, $actualDetails->getValue());
+        $this->assertNull($actualDetails->getVariant());
+        $this->assertEquals('DISABLED', $actualDetails->getReason());
+    }
+
+    private function providerWithResponseBody(string $body): FlagdProvider
+    {
+        $mockRequest = $this->mockery(RequestInterface::class);
+        $mockRequest->shouldReceive('withHeader')->andReturn($mockRequest);
+        $mockRequest->shouldReceive('withBody')->andReturn($mockRequest);
+
+        $mockRequestFactory = $this->mockery(RequestFactoryInterface::class);
+        $mockRequestFactory->shouldReceive('createRequest')->andReturn($mockRequest);
+
+        $mockStream = $this->mockery(StreamInterface::class);
+
+        $mockStreamFactory = $this->mockery(StreamFactoryInterface::class);
+        $mockStreamFactory->shouldReceive('createStream')->andReturn($mockStream);
+
+        $mockResponse = $this->mockery(ResponseInterface::class);
+        $mockResponse->shouldReceive('getBody->__toString')->andReturn($body);
+
+        $mockClient = $this->mockery(ClientInterface::class);
+        $mockClient->shouldReceive('sendRequest')->with($mockRequest)->andReturn($mockResponse);
+
+        /** @var ClientInterface $client */
+        $client = $mockClient;
+        /** @var RequestFactoryInterface $requestFactory */
+        $requestFactory = $mockRequestFactory;
+        /** @var StreamFactoryInterface $streamFactory */
+        $streamFactory = $mockStreamFactory;
+
+        return new FlagdProvider([
+            'httpConfig' => [
+                'client' => $client,
+                'requestFactory' => $requestFactory,
+                'streamFactory' => $streamFactory,
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
flagd 0.16+ returns a successful response with reason=DISABLED and the type's zero value instead of an error for disabled flags. The HTTP resolver had no reason-based check, so it returned the wire zero value instead of the caller-provided default.

Fixes #171