### PR TITLE
chore: add e2e tests for flagd

### DIFF
--- a/.github/workflows/php-ci.yaml
+++ b/.github/workflows/php-ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   php:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-ci.yaml
+++ b/.github/workflows/php-ci.yaml
@@ -95,9 +95,6 @@ jobs:
         vendor/bin/phpunit --coverage-text --coverage-clover=coverage.integration.xml --testsuite integration
         composer run dev:test:integration:teardown
 
-    # Behat/gherkin e2e runs only on the latest matrix PHP (some e2e tooling, e.g. testcontainers,
-    # needs a newer PHP than the whole matrix supports). Every package defines dev:test:e2e; it is a
-    # no-op where there is no suite, and owns its own setup/run/teardown and deps where there is one.
     - name: Run e2e suite (Behat)
       if: matrix.php-version == '8.2'
       working-directory: ${{ matrix.project-dir }}

--- a/.github/workflows/php-ci.yaml
+++ b/.github/workflows/php-ci.yaml
@@ -20,7 +20,8 @@ jobs:
           - providers/Flagd
           - providers/Split
           - providers/GoFeatureFlag
-          # - providers/CloudBees
+          # - providers/CloudBees  # disabled: revert after issue is resolved (#92)
+          # - providers/Flagsmith  # not yet wired into CI
       fail-fast: false
 
     # todo exclude some matrix combinations based on php version requirements
@@ -93,6 +94,14 @@ jobs:
         composer run dev:test:integration:setup
         vendor/bin/phpunit --coverage-text --coverage-clover=coverage.integration.xml --testsuite integration
         composer run dev:test:integration:teardown
+
+    # Behat/gherkin e2e runs only on the latest matrix PHP (some e2e tooling, e.g. testcontainers,
+    # needs a newer PHP than the whole matrix supports). Every package defines dev:test:e2e; it is a
+    # no-op where there is no suite, and owns its own setup/run/teardown and deps where there is one.
+    - name: Run e2e suite (Behat)
+      if: matrix.php-version == '8.2'
+      working-directory: ${{ matrix.project-dir }}
+      run: composer run dev:test:e2e
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "schemas"]
 	path = providers/Flagd/schemas
 	url = https://github.com/tcarrio/schemas/
+[submodule "providers/Flagd/test-harness"]
+	path = providers/Flagd/test-harness
+	url = https://github.com/open-feature/flagd-testbed.git

--- a/hooks/DDTrace/composer.json
+++ b/hooks/DDTrace/composer.json
@@ -111,6 +111,7 @@
     "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
     "dev:test:unit:setup": "echo 'Setup for unit tests...'",
     "dev:test:unit:teardown": "echo 'Tore down for unit tests...'",
+    "dev:test:e2e": "echo 'No e2e tests for this package.'",
     "dev:test:integration": [
       "@dev:test:integration:setup",
       "phpunit --colors=always --testdox --testsuite=integration",

--- a/hooks/OpenTelemetry/composer.json
+++ b/hooks/OpenTelemetry/composer.json
@@ -110,6 +110,7 @@
     "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
     "dev:test:unit:setup": "echo 'Setup for unit tests...'",
     "dev:test:unit:teardown": "echo 'Tore down for unit tests...'",
+    "dev:test:e2e": "echo 'No e2e tests for this package.'",
     "dev:test:integration": [
       "@dev:test:integration:setup",
       "phpunit --colors=always --testdox --testsuite=integration",

--- a/hooks/Validators/composer.json
+++ b/hooks/Validators/composer.json
@@ -105,6 +105,7 @@
     "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
     "dev:test:unit:setup": "echo 'Setup for unit tests...'",
     "dev:test:unit:teardown": "echo 'Tore down for unit tests...'",
+    "dev:test:e2e": "echo 'No e2e tests for this package.'",
     "dev:test:integration": [
       "@dev:test:integration:setup",
       "phpunit --colors=always --testdox --testsuite=integration",

--- a/providers/Flagd/.gitignore
+++ b/providers/Flagd/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /vendor
 /build
+/behat.yml

--- a/providers/Flagd/behat.yml.dist
+++ b/providers/Flagd/behat.yml.dist
@@ -1,0 +1,11 @@
+default:
+  suites:
+    evaluation:
+      paths:
+        - '%paths.base%/test-harness/gherkin/evaluation.feature'
+      contexts:
+        - OpenFeature\Providers\Flagd\Test\e2e\bootstrap\FlagdContext
+  gherkin:
+    filters:
+      # the @deprecated scenarios assert legacy no-default semantics the provider intentionally does not implement
+      tags: "~@deprecated"

--- a/providers/Flagd/composer.json
+++ b/providers/Flagd/composer.json
@@ -30,8 +30,11 @@
     "psr/log": "^2.0 || ^3.0"
   },
   "require-dev": {
+    "behat/behat": "^3.13",
     "ergebnis/composer-normalize": "^2.25",
     "friendsofphp/php-cs-fixer": "^3.13",
+    "guzzlehttp/guzzle": "^7.5",
+    "guzzlehttp/psr7": "^2.4",
     "hamcrest/hamcrest-php": "^2.0",
     "mdwheele/zalgo": "^0.3.1",
     "mockery/mockery": "^1.5",
@@ -50,6 +53,9 @@
     "roave/security-advisories": "dev-latest",
     "spatie/phpunit-snapshot-assertions": "^4.2",
     "vimeo/psalm": "~4.30.0"
+  },
+  "suggest": {
+    "testcontainers/testcontainers": "Required (PHP >= 8.1) to run the opt-in Behat e2e suite (composer dev:test:e2e)"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
@@ -105,17 +111,27 @@
     "dev:test": [
       "@dev:lint",
       "@dev:analyze",
-      "@dev:test:unit",
-      "@dev:test:integration"
+      "@dev:test:unit"
     ],
     "dev:test:coverage:ci": "phpunit --colors=always --coverage-text --coverage-clover build/coverage/clover.xml --coverage-cobertura build/coverage/cobertura.xml --coverage-crap4j build/coverage/crap4j.xml --coverage-xml build/coverage/coverage-xml --log-junit build/junit.xml",
     "dev:test:coverage:html": "phpunit --colors=always --coverage-html build/coverage/coverage-html/",
+    "dev:test:e2e": [
+      "@dev:test:e2e:setup",
+      "@dev:test:e2e:run",
+      "@dev:test:e2e:teardown"
+    ],
+    "dev:test:e2e:run": "behat --colors",
+    "dev:test:e2e:setup": [
+      "git submodule update --init --recursive -- test-harness",
+      "composer require --dev --no-interaction --no-progress \"testcontainers/testcontainers:^1.0\""
+    ],
+    "dev:test:e2e:teardown": "echo 'Tore down e2e tests...'",
+    "dev:test:integration:setup": "echo 'Setup for integration tests...'",
+    "dev:test:integration:teardown": "echo 'Tore down integration tests...'",
     "dev:test:unit": "phpunit --colors=always --testdox",
     "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
     "dev:test:unit:setup": "echo 'Setup for unit tests...'",
     "dev:test:unit:teardown": "echo 'Tore down unit tests...'",
-    "dev:test:integration:setup": "echo 'Setup for integration tests...'",
-    "dev:test:integration:teardown": "echo 'Tore down integration tests...'",
     "test": "@dev:test"
   },
   "scripts-descriptions": {
@@ -130,6 +146,7 @@
     "dev:test": "Runs linting, static analysis, and unit tests.",
     "dev:test:coverage:ci": "Runs unit tests and generates CI coverage reports.",
     "dev:test:coverage:html": "Runs unit tests and generates HTML coverage report.",
+    "dev:test:e2e": "Runs the opt-in Behat/gherkin e2e suite (setup, run, teardown) against a flagd testbed container.",
     "dev:test:unit": "Runs unit tests.",
     "test": "Runs linting, static analysis, and unit tests."
   }

--- a/providers/Flagd/phpstan.neon.dist
+++ b/providers/Flagd/phpstan.neon.dist
@@ -7,5 +7,7 @@ parameters:
     excludePaths:
         - */tests/fixtures/*
         - */tests/*/fixtures/*
+        # e2e bootstrap depends on testcontainers, a dev dep only installed for the opt-in e2e job
+        - ./tests/e2e
         # TODO: Implement gRPC Completely
         - ./src/grpc

--- a/providers/Flagd/tests/e2e/bootstrap/ExposingGenericContainer.php
+++ b/providers/Flagd/tests/e2e/bootstrap/ExposingGenericContainer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Providers\Flagd\Test\e2e\bootstrap;
+
+use Docker\API\Model\ContainerConfigExposedPortsItem;
+use Docker\API\Model\ContainersCreatePostBody;
+use Testcontainers\Container\GenericContainer;
+
+/**
+ * GenericContainer that also declares the exposed ports in the container's `Config.ExposedPorts`.
+ *
+ * testcontainers-php only sets `HostConfig.PortBindings`, not `Config.ExposedPorts`. For images
+ * that do not `EXPOSE` their ports (the flagd testbed image does not), some Docker daemons then
+ * report an empty `NetworkSettings.Ports`, so `getMappedPort()` cannot resolve the host port. This
+ * is observed on GitHub Actions runners while local Docker is lenient. Declaring the ports fixes it.
+ */
+final class ExposingGenericContainer extends GenericContainer
+{
+    protected function createContainerConfig(): ContainersCreatePostBody
+    {
+        $config = parent::createContainerConfig();
+
+        $exposed = [];
+        foreach ($this->exposedPorts as $port) {
+            $item = new ContainerConfigExposedPortsItem();
+            $item['exposed'] = true;
+            $exposed[$port] = $item;
+        }
+
+        if ($exposed !== []) {
+            $config->setExposedPorts($exposed);
+        }
+
+        return $config;
+    }
+}

--- a/providers/Flagd/tests/e2e/bootstrap/FlagdContext.php
+++ b/providers/Flagd/tests/e2e/bootstrap/FlagdContext.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Providers\Flagd\Test\e2e\bootstrap;
+
+use Behat\Behat\Context\Context;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\HttpFactory;
+use OpenFeature\Providers\Flagd\FlagdProvider;
+use OpenFeature\Providers\Flagd\config\ConfigFactory;
+use OpenFeature\Providers\Flagd\config\HttpConfig;
+use OpenFeature\implementation\flags\Attributes;
+use OpenFeature\implementation\flags\EvaluationContext;
+use OpenFeature\interfaces\flags\EvaluationContext as EvaluationContextInterface;
+use OpenFeature\interfaces\provider\Provider;
+use OpenFeature\interfaces\provider\ResolutionDetails;
+use PHPUnit\Framework\Assert;
+use RuntimeException;
+
+use function getenv;
+use function is_array;
+use function json_decode;
+use function strtolower;
+
+/**
+ * Behat step definitions for the flagd testbed gherkin suite, driving a real HTTP-only
+ * FlagdProvider against a flagd testbed container. Only the evaluation feature is wired up
+ * (see behat.yml.dist); this is an opt-in e2e suite.
+ */
+final class FlagdContext implements Context
+{
+    private static ?FlagdTestbedContainer $testbed = null;
+    private static string $host;
+    private static int $port;
+
+    private Provider $provider;
+
+    /** @var array<string, bool|float|int|string|mixed[]|null> */
+    private array $attributes = [];
+    private ?string $targetingKey = null;
+
+    private string $flagType;
+    private string $flagKey;
+    private string $defaultValue;
+    private ResolutionDetails $details;
+
+    /**
+     * @BeforeSuite
+     */
+    public static function startTestbed(): void
+    {
+        // Allow pointing at an already-running flagd (e.g. started by CI) instead of a container.
+        $host = getenv('FLAGD_HOST');
+        $port = getenv('FLAGD_PORT');
+
+        if ($host !== false && $host !== '' && $port !== false && $port !== '') {
+            self::$host = $host;
+            self::$port = (int) $port;
+
+            return;
+        }
+
+        self::$testbed = FlagdTestbedContainer::start();
+        self::$host = self::$testbed->getHost();
+        self::$port = self::$testbed->getPort();
+    }
+
+    /**
+     * @AfterSuite
+     */
+    public static function stopTestbed(): void
+    {
+        self::$testbed?->stop();
+        self::$testbed = null;
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    public function prepareProvider(): void
+    {
+        $client = new GuzzleClient(['http_errors' => false]);
+        $factory = new HttpFactory();
+
+        $config = ConfigFactory::fromOptions(
+            self::$host,
+            self::$port,
+            'http',
+            false,
+            new HttpConfig($client, $factory, $factory),
+        );
+
+        $this->provider = new FlagdProvider($config);
+        $this->attributes = [];
+        $this->targetingKey = null;
+    }
+
+    /**
+     * @Given /^an option "[^"]*" of type "[^"]*" with value "[^"]*"$/
+     */
+    public function anOption(): void
+    {
+        // no-op: the HTTP-only PHP provider is stateless (no caching/streaming options)
+    }
+
+    /**
+     * @Given /^a stable flagd provider$/
+     */
+    public function aStableFlagdProvider(): void
+    {
+        // provider is (re)created per scenario in prepareProvider()
+    }
+
+    /**
+     * @Given /^a (?P<type>\w+)-flag with key "(?P<key>[^"]*)" and a default value "(?P<default>[^"]*)"$/
+     */
+    public function aFlagWithKeyAndDefault(string $type, string $key, string $default): void
+    {
+        $this->flagType = $type;
+        $this->flagKey = $key;
+        $this->defaultValue = $default;
+    }
+
+    /**
+     * @Given /^a context containing a key "(?P<key>[^"]*)", with type "(?P<type>[^"]*)" and with value "(?P<value>[^"]*)"$/
+     */
+    public function aContextContainingKey(string $key, string $type, string $value): void
+    {
+        $this->attributes[$key] = self::cast($type, $value);
+    }
+
+    /**
+     * @When /^the flag was evaluated with details$/
+     */
+    public function theFlagWasEvaluatedWithDetails(): void
+    {
+        $context = $this->buildContext();
+
+        switch ($this->flagType) {
+            case 'Boolean':
+                $this->details = $this->provider->resolveBooleanValue($this->flagKey, strtolower($this->defaultValue) === 'true', $context);
+
+                break;
+            case 'String':
+                $this->details = $this->provider->resolveStringValue($this->flagKey, $this->defaultValue, $context);
+
+                break;
+            case 'Integer':
+                $this->details = $this->provider->resolveIntegerValue($this->flagKey, (int) $this->defaultValue, $context);
+
+                break;
+            case 'Float':
+                $this->details = $this->provider->resolveFloatValue($this->flagKey, (float) $this->defaultValue, $context);
+
+                break;
+            case 'Object':
+                $decoded = json_decode($this->defaultValue, true);
+                $this->details = $this->provider->resolveObjectValue($this->flagKey, is_array($decoded) ? $decoded : [], $context);
+
+                break;
+            default:
+                throw new RuntimeException('Unsupported flag type: ' . $this->flagType);
+        }
+    }
+
+    /**
+     * @Then /^the resolved details value should be "(?P<value>[^"]*)"$/
+     */
+    public function theResolvedValueShouldBe(string $value): void
+    {
+        Assert::assertEquals(self::cast($this->flagType, $value), $this->details->getValue());
+    }
+
+    /**
+     * @Then /^the reason should be "(?P<reason>[^"]*)"$/
+     */
+    public function theReasonShouldBe(string $reason): void
+    {
+        Assert::assertEquals($reason, $this->details->getReason());
+    }
+
+    /**
+     * @Then /^the error-code should be "(?P<code>[^"]*)"$/
+     */
+    public function theErrorCodeShouldBe(string $code): void
+    {
+        $error = $this->details->getError();
+
+        if ($code === '') {
+            Assert::assertNull($error);
+
+            return;
+        }
+
+        Assert::assertNotNull($error);
+        Assert::assertEquals($code, (string) $error->getResolutionErrorCode()->getValue());
+    }
+
+    private function buildContext(): ?EvaluationContextInterface
+    {
+        if ($this->attributes === [] && $this->targetingKey === null) {
+            return null;
+        }
+
+        return new EvaluationContext($this->targetingKey, new Attributes($this->attributes));
+    }
+
+    /**
+     * @return bool|float|int|string|mixed[]|null
+     */
+    private static function cast(string $type, string $value)
+    {
+        switch ($type) {
+            case 'Boolean':
+                return strtolower($value) === 'true';
+            case 'Integer':
+                return (int) $value;
+            case 'Float':
+                return (float) $value;
+            case 'Object':
+                $decoded = json_decode($value, true);
+
+                return is_array($decoded) ? $decoded : null;
+            case 'String':
+            default:
+                return $value;
+        }
+    }
+}

--- a/providers/Flagd/tests/e2e/bootstrap/FlagdTestbedContainer.php
+++ b/providers/Flagd/tests/e2e/bootstrap/FlagdTestbedContainer.php
@@ -45,20 +45,28 @@ final class FlagdTestbedContainer
             ->withExposedPorts(self::EVALUATION_PORT, self::HEALTH_PORT, self::LAUNCHPAD_PORT)
             ->start();
 
-        $host = $started->getHost();
-        $id = $started->getId();
+        try {
+            $host = $started->getHost();
+            $id = $started->getId();
 
-        $launchpadPort = self::mappedPort($started, $id, self::LAUNCHPAD_PORT);
-        $healthPort = self::mappedPort($started, $id, self::HEALTH_PORT);
-        $evaluationPort = self::mappedPort($started, $id, self::EVALUATION_PORT);
+            $launchpadPort = self::mappedPort($started, $id, self::LAUNCHPAD_PORT);
+            $healthPort = self::mappedPort($started, $id, self::HEALTH_PORT);
+            $evaluationPort = self::mappedPort($started, $id, self::EVALUATION_PORT);
 
-        $launchpad = sprintf('http://%s:%d', $host, $launchpadPort);
-        $healthUrl = sprintf('http://%s:%d/healthz', $host, $healthPort);
+            $launchpad = sprintf('http://%s:%d', $host, $launchpadPort);
+            $healthUrl = sprintf('http://%s:%d/healthz', $host, $healthPort);
 
-        $client = new GuzzleClient(['http_errors' => false, 'timeout' => 5]);
+            $client = new GuzzleClient(['http_errors' => false, 'timeout' => 5]);
 
-        self::poll(fn (): bool => $client->post($launchpad . '/start')->getStatusCode() === 200);
-        self::poll(fn (): bool => $client->get($healthUrl)->getStatusCode() === 200);
+            self::poll(fn (): bool => $client->post($launchpad . '/start')->getStatusCode() === 200);
+            self::poll(fn (): bool => $client->get($healthUrl)->getStatusCode() === 200);
+        } catch (Throwable $e) {
+            // the container is already running; stop it so a failed startup doesn't leak it,
+            // since @AfterSuite can only clean up once this method returns a wrapper instance
+            $started->stop();
+
+            throw $e;
+        }
 
         return new self($started, $host, $evaluationPort);
     }

--- a/providers/Flagd/tests/e2e/bootstrap/FlagdTestbedContainer.php
+++ b/providers/Flagd/tests/e2e/bootstrap/FlagdTestbedContainer.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Providers\Flagd\Test\e2e\bootstrap;
+
+use GuzzleHttp\Client as GuzzleClient;
+use RuntimeException;
+use Testcontainers\Container\GenericContainer;
+use Testcontainers\Container\StartedGenericContainer;
+use Throwable;
+
+use function file_get_contents;
+use function rtrim;
+use function sprintf;
+use function usleep;
+
+/**
+ * Boots the flagd testbed image and drives its launchpad so flagd is serving the
+ * default flag set before tests run. Only the RPC/HTTP evaluation port (8013) is
+ * needed; the PHP provider is HTTP-only, so no gRPC or sync ports are wired up.
+ */
+final class FlagdTestbedContainer
+{
+    private const IMAGE = 'ghcr.io/open-feature/flagd-testbed';
+    private const EVALUATION_PORT = 8013;
+    private const HEALTH_PORT = 8014;
+    private const LAUNCHPAD_PORT = 8080;
+
+    private StartedGenericContainer $container;
+    private string $host;
+    private int $evaluationPort;
+
+    private function __construct(StartedGenericContainer $container, string $host, int $evaluationPort)
+    {
+        $this->container = $container;
+        $this->host = $host;
+        $this->evaluationPort = $evaluationPort;
+    }
+
+    public static function start(): self
+    {
+        $image = sprintf('%s:v%s', self::IMAGE, self::resolveVersion());
+
+        $started = (new GenericContainer($image))
+            ->withExposedPorts(self::EVALUATION_PORT, self::HEALTH_PORT, self::LAUNCHPAD_PORT)
+            ->start();
+
+        $host = $started->getHost();
+        $launchpad = sprintf('http://%s:%d', $host, $started->getMappedPort(self::LAUNCHPAD_PORT));
+        $healthUrl = sprintf('http://%s:%d/healthz', $host, $started->getMappedPort(self::HEALTH_PORT));
+
+        $client = new GuzzleClient(['http_errors' => false, 'timeout' => 5]);
+
+        self::poll(fn (): bool => $client->post($launchpad . '/start')->getStatusCode() === 200);
+        self::poll(fn (): bool => $client->get($healthUrl)->getStatusCode() === 200);
+
+        return new self($started, $host, $started->getMappedPort(self::EVALUATION_PORT));
+    }
+
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    public function getPort(): int
+    {
+        return $this->evaluationPort;
+    }
+
+    public function stop(): void
+    {
+        $this->container->stop();
+    }
+
+    /**
+     * @param callable(): bool $probe
+     */
+    private static function poll(callable $probe, int $attempts = 60, int $intervalMs = 500): void
+    {
+        for ($i = 0; $i < $attempts; $i++) {
+            try {
+                if ($probe()) {
+                    return;
+                }
+            } catch (Throwable $e) {
+                // swallow until the deadline; flagd may not be listening yet
+            }
+
+            usleep($intervalMs * 1000);
+        }
+
+        throw new RuntimeException('flagd testbed did not become ready in time');
+    }
+
+    private static function resolveVersion(): string
+    {
+        $version = @file_get_contents(__DIR__ . '/../../../test-harness/version.txt');
+
+        if ($version === false) {
+            throw new RuntimeException('Unable to read test-harness/version.txt; is the submodule initialized?');
+        }
+
+        return rtrim($version);
+    }
+}

--- a/providers/Flagd/tests/e2e/bootstrap/FlagdTestbedContainer.php
+++ b/providers/Flagd/tests/e2e/bootstrap/FlagdTestbedContainer.php
@@ -6,7 +6,6 @@ namespace OpenFeature\Providers\Flagd\Test\e2e\bootstrap;
 
 use GuzzleHttp\Client as GuzzleClient;
 use RuntimeException;
-use Testcontainers\Container\GenericContainer;
 use Testcontainers\Container\StartedGenericContainer;
 use Throwable;
 
@@ -42,20 +41,26 @@ final class FlagdTestbedContainer
     {
         $image = sprintf('%s:v%s', self::IMAGE, self::resolveVersion());
 
-        $started = (new GenericContainer($image))
+        $started = (new ExposingGenericContainer($image))
             ->withExposedPorts(self::EVALUATION_PORT, self::HEALTH_PORT, self::LAUNCHPAD_PORT)
             ->start();
 
         $host = $started->getHost();
-        $launchpad = sprintf('http://%s:%d', $host, $started->getMappedPort(self::LAUNCHPAD_PORT));
-        $healthUrl = sprintf('http://%s:%d/healthz', $host, $started->getMappedPort(self::HEALTH_PORT));
+        $id = $started->getId();
+
+        $launchpadPort = self::mappedPort($started, $id, self::LAUNCHPAD_PORT);
+        $healthPort = self::mappedPort($started, $id, self::HEALTH_PORT);
+        $evaluationPort = self::mappedPort($started, $id, self::EVALUATION_PORT);
+
+        $launchpad = sprintf('http://%s:%d', $host, $launchpadPort);
+        $healthUrl = sprintf('http://%s:%d/healthz', $host, $healthPort);
 
         $client = new GuzzleClient(['http_errors' => false, 'timeout' => 5]);
 
         self::poll(fn (): bool => $client->post($launchpad . '/start')->getStatusCode() === 200);
         self::poll(fn (): bool => $client->get($healthUrl)->getStatusCode() === 200);
 
-        return new self($started, $host, $started->getMappedPort(self::EVALUATION_PORT));
+        return new self($started, $host, $evaluationPort);
     }
 
     public function getHost(): string
@@ -74,9 +79,44 @@ final class FlagdTestbedContainer
     }
 
     /**
+     * Resolves a container's published host port for an exposed port. Docker can take a moment
+     * after start to publish the bindings, and StartedGenericContainer caches its inspect, so a
+     * fresh instance is used on each attempt to force an uncached lookup (see
+     * testcontainers/testcontainers-php#50). On timeout the container logs are surfaced to aid
+     * diagnosis on CI runners.
+     */
+    private static function mappedPort(StartedGenericContainer $started, string $id, int $port, int $attempts = 40, int $intervalMs = 250): int
+    {
+        for ($i = 0; $i < $attempts; $i++) {
+            try {
+                return (new StartedGenericContainer($id))->getMappedPort($port);
+            } catch (Throwable $e) {
+                // bindings not published yet; retry until the deadline
+            }
+
+            usleep($intervalMs * 1000);
+        }
+
+        throw new RuntimeException(sprintf(
+            "flagd testbed did not publish port %d in time.\n--- container logs ---\n%s",
+            $port,
+            self::safeLogs($started),
+        ));
+    }
+
+    private static function safeLogs(StartedGenericContainer $started): string
+    {
+        try {
+            return $started->logs();
+        } catch (Throwable $e) {
+            return '(unable to read container logs: ' . $e->getMessage() . ')';
+        }
+    }
+
+    /**
      * @param callable(): bool $probe
      */
-    private static function poll(callable $probe, int $attempts = 60, int $intervalMs = 500): void
+    private static function poll(callable $probe, int $attempts = 20, int $intervalMs = 500): void
     {
         for ($i = 0; $i < $attempts; $i++) {
             try {

--- a/providers/GoFeatureFlag/composer.json
+++ b/providers/GoFeatureFlag/composer.json
@@ -95,6 +95,7 @@
     "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
     "dev:test:unit:setup": "echo 'Setup for unit tests...'",
     "dev:test:unit:teardown": "echo 'Tore down for unit tests...'",
+    "dev:test:e2e": "echo 'No e2e tests for this package.'",
     "dev:test:integration": [
       "@dev:test:integration:setup",
       "phpunit --colors=always --testdox --testsuite=integration",

--- a/providers/Split/composer.json
+++ b/providers/Split/composer.json
@@ -107,6 +107,7 @@
     "dev:test:unit:debug": "phpunit --colors=always --testdox -d xdebug.profiler_enable=on",
     "dev:test:unit:setup": "echo 'Setup for unit tests...'",
     "dev:test:unit:teardown": "echo 'Tore down for unit tests...'",
+    "dev:test:e2e": "echo 'No e2e tests for this package.'",
     "dev:test:integration": [
       "@dev:test:integration:setup",
       "phpunit --colors=always --testdox --testsuite=integration",


### PR DESCRIPTION
Adds a minimal e2e test implementation (remote only since PHP has no in-process eval).